### PR TITLE
v0.2.16 (in progress): port non-MCP, non-steps work from feature/mcp-support

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -8,7 +8,7 @@ on:
   # push:
   #   branches: [ master,main,release ]
   pull_request:
-    branches: [ master,main,release,stage ]
+    branches: [ master,main,release,stage,dev ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ The full list lives in the [docs](https://docs.fastdash.app).
 
 - **Output labels are inferred from the `return` line of your source.** If the source can't be retrieved (REPL, `exec`, frozen environments), Fast Dash falls back to generic `OUTPUT_1`, `OUTPUT_2` labels rather than crashing. Pass `output_labels=[...]` explicitly to control them.
 - **Reusing component instances across inputs and outputs** can mutate shared attributes. Construct fresh components per slot (or use `inputs=Text` rather than `inputs=text_instance`).
-- **The `theme` arg expects a Bootswatch name**, not a CSS URL. Theme drives both the Bootstrap stylesheet and the dark/light mode (Bootswatch's dark themes — `CYBORG`, `DARKLY`, `SLATE`, etc. — auto-enable dark mode).
+- **The `theme` arg expects a Bootswatch name**, not a CSS URL. The chrome (header, navbar, buttons, inputs) is rendered with Mantine components and does not pick up Bootswatch accent colors or fonts — only the dark/light mode flips for known dark themes (`CYBORG`, `DARKLY`, `QUARTZ`, `SLATE`, `SOLAR`, `SUPERHERO`, `VAPOR`). Bootswatch CSS still loads and styles `dbc`-rendered bits (e.g. data tables).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -99,10 +99,9 @@ Outputs (return type → UI component):
 | `str`, `int`, `float`, etc. | Text (rendered as `<h1>`) |
 | `pd.DataFrame` | Table |
 | `PIL.Image.Image`, `matplotlib.figure.Figure` | Image |
+| `plotly.graph_objects.Figure` (or string-form `"go.Figure"`, `"Figure"`) | Plotly chart |
 | Tuple of types | Multiple outputs (one component each) |
 | Any Fast Dash component (`Graph`, `Image`, ...) | Used directly |
-
-For **Plotly figures**, annotate the return as `Graph` rather than `plotly.graph_objects.Figure` — the latter is not auto-detected:
 
 ```python
 from fast_dash import fastdash, Graph
@@ -114,6 +113,23 @@ def chart(rows: int = 100) -> Graph:
 ```
 
 Unknown hints fall back to text. Source-introspection failures (REPL, `exec`) fall back to generic `OUTPUT_1`, `OUTPUT_2` labels — the app still works.
+
+### Built-in components
+
+The package exports ready-to-use Fast Dash components you can pass directly as `inputs=` or `outputs=`:
+
+| Component | Use as | Notes |
+| --- | --- | --- |
+| `Text`, `TextArea`, `PasswordInput` | input or output | Single-line, multi-line, masked text |
+| `NumberInput`, `Slider` | input | Numeric with optional bounds |
+| `Switch` | input | Toggle (True / False) |
+| `MultiSelect` | input | Multi-select dropdown |
+| `DateInput`, `DateRange` | input | Single date / date range picker |
+| `ColorInput` | input | Color picker, returns hex |
+| `Upload`, `UploadImage` | input | File / image upload |
+| `Graph`, `Image`, `Table`, `Markdown` | output | Plotly chart, image, DataFrame table, rendered Markdown |
+| `Chat` | output | Streaming chat history (with `stream=True`) |
+| `Download` | output | Triggers a browser download |
 
 ## Common patterns
 
@@ -159,6 +175,29 @@ custom_slider = Fastify(dcc.Slider(min=0, max=100, value=50), "value")
 def my_app(x: custom_slider) -> str:
     return f"You picked {x}"
 ```
+
+**Cascading inputs** with `depends_on` — wire one input's options to another input's value:
+
+```python
+from fast_dash import fastdash, depends_on
+
+countries = {
+    "USA": ["California", "Texas", "New York"],
+    "India": ["Maharashtra", "Karnataka", "Delhi"],
+}
+
+@fastdash
+def pick_state(
+    country: str = list(countries),
+    state: str = depends_on("country", lambda c: countries[c]),
+) -> str:
+    return f"{state}, {country}"
+```
+
+The resolver receives the parent input's current value. Return:
+- a **list** to set the dependent dropdown's options (and clear its value),
+- a **dict** like `{"data": [...], "value": ...}` to set both, or
+- a **scalar** to set just the value.
 
 **Skip the decorator** when you want more control over the lifecycle:
 

--- a/README.md
+++ b/README.md
@@ -227,6 +227,29 @@ app.run()
 
 Each function gets its own tab with independent inputs, outputs, and callbacks. `tab_titles` is optional — without it, tabs are named after the functions.
 
+**Multi-step pipelines** with `steps=` — chain functions into a wizard, threading outputs forward via `from_step`:
+
+```python
+from fast_dash import FastDash, from_step
+import pandas as pd
+
+def load_data(rows: int = 100) -> pd.DataFrame:
+    """Load a sample dataset."""
+    return pd.DataFrame({"x": range(rows), "y": [i * 2 for i in range(rows)]})
+
+def double(data=from_step(load_data)) -> pd.DataFrame:
+    """Double every value."""
+    return data * 2
+
+def summarise(data=from_step(double), prefix: str = "Result:") -> str:
+    """One-line summary."""
+    return f"{prefix} {len(data)} rows, sum={data.values.sum()}"
+
+FastDash(steps=[load_data, double, summarise], title="Pipeline Demo").run()
+```
+
+Each step is shown one at a time with a stepper progress indicator. Click **Run** to execute the active step, then **Next** to advance. Use `from_step(prev_fn)` as a parameter default to wire an upstream output into a downstream input. Steps without `from_step` parameters can mix in regular UI inputs (like `prefix` above).
+
 ## Decorator options
 
 Most apps need none of these — defaults are sensible. Pass any of them as kwargs to `@fastdash(...)` or `FastDash(...)`.

--- a/docs/User guide/build.md
+++ b/docs/User guide/build.md
@@ -234,6 +234,9 @@ def yourFunction(...):
     ...
 ```
 
+!!! note "Current limitation"
+    The chrome (header, navbar, buttons, inputs) is rendered with Mantine components and does not pick up Bootswatch accent colors or fonts — only the dark/light mode flips for known dark themes (`CYBORG`, `DARKLY`, `QUARTZ`, `SLATE`, `SOLAR`, `SUPERHERO`, `VAPOR`). Bootswatch CSS still loads and styles `dbc`-rendered bits (e.g. data tables).
+
 ##### 8. Update Live
 
 By default, Fast Dash apps update lazily. That means once the user enters inputs, the outputs update only after they click `Submit`. But on setting the `update_live` argument to `True`, the `Submit` and `Reset` buttons disappear, and the outputs update instantaneously. This feature is also popularly known as hot reloading.

--- a/docs/User guide/patterns.md
+++ b/docs/User guide/patterns.md
@@ -254,7 +254,53 @@ The first argument to `depends_on` is the **parameter name** of the parent input
 
 If the resolver raises an exception, no update fires. Chains work: `A → B → C` is just two `depends_on` declarations.
 
-## 6. Selecting other configurations
+## 6. Multi-step pipelines
+
+When your workflow naturally splits into stages — load data → transform → visualize — turn the whole pipeline into a single app with `steps=`:
+
+```py linenums="1"
+from fast_dash import FastDash, from_step
+import pandas as pd
+
+def load_data(rows: int = 100) -> pd.DataFrame:
+    """Load a sample dataset."""
+    return pd.DataFrame({"x": range(rows), "y": [i * 2 for i in range(rows)]})
+
+def double(data=from_step(load_data)) -> pd.DataFrame:
+    """Double every value."""
+    return data * 2
+
+def summarise(data=from_step(double), prefix: str = "Result:") -> str:
+    """One-line summary."""
+    return f"{prefix} {len(data)} rows, sum={data.values.sum()}"
+
+FastDash(steps=[load_data, double, summarise], title="Pipeline Demo").run()
+```
+
+Each step is rendered as a dedicated panel with its own inputs and outputs. A stepper progress indicator at the top of the main area shows the current step. Click **Run** to execute the active step, then **Next** to advance.
+
+### Wiring upstream outputs into downstream inputs
+
+Use `from_step(prev_fn)` as a parameter default to pull a previous step's return value into the current step's parameter:
+
+- The framework caches each step's return value per browser session.
+- When a downstream step runs, `from_step` parameters are filled in automatically — no UI is rendered for them.
+- Mix `from_step` parameters with regular UI parameters freely (see `summarise`'s `prefix` above).
+- `from_step(prev_fn, transform=lambda x: ...)` applies a function to the cached value before passing it.
+
+### Navigation and state
+
+- **Back** rewinds one step and clears all downstream cached results, so you can rerun a different branch of inputs.
+- **Run** executes the currently visible step. Until you click Run, the **Next** button is disabled.
+- Trying to run a downstream step before its `from_step` source has been run produces a friendly error message instead of a traceback.
+- State is keyed by a UUID stored in the browser's session storage, so opening the app in a new tab gives you a fresh pipeline.
+
+### Limits
+
+- Linear pipelines only — no conditional branching in this release.
+- The cache lives in the FastDash process; a server restart or a multi-worker deployment loses session state. Acceptable for prototyping.
+
+## 7. Selecting other configurations
 
 Finally, customize your app by controlling various options like the theme of the app, social media branding links, subheaders, deployment mode and so on.
 

--- a/docs/User guide/patterns.md
+++ b/docs/User guide/patterns.md
@@ -48,6 +48,8 @@ Here are some examples:
 | Bounded number via type hint | `Annotated[int, range(min, max, step)]` | Any int/float | `def score(s: Annotated[int, range(0, 100)])` |
 | Dropdown via type hint | `Annotated[str, [list]]` | Any of the values | `def pick(c: Annotated[str, ["USA", "Canada"]])` |
 | Optional value | `Optional[T]` | Any `T` | `def ping(text: Optional[str])` |
+<b>Reactive inputs<b>
+| Cascading dropdown | Use `depends_on(parent, resolver)` as the default | The parent input's name and a resolver that returns options | `def pick(country: str = ["USA"], state: str = depends_on("country", lambda c: states[c]))` |
 
 
 ## 2. Setting output components
@@ -224,7 +226,35 @@ app.run()
 
 `tab_titles` is optional — without it, tabs are named after the functions (converted from `snake_case` to Title Case). The navbar, about modal, and streaming notifications are shared across all tabs; component IDs are namespaced per tab so they don't collide.
 
-## 5. Selecting other configurations
+## 5. Reactive inputs with `depends_on`
+
+When one input's options should depend on another input's value (cascading dropdowns, dynamic ranges, prefilled values), use `depends_on` as the dependent parameter's default:
+
+```py linenums="1"
+from fast_dash import fastdash, depends_on
+
+countries = {
+    "USA": ["California", "Texas", "New York"],
+    "India": ["Maharashtra", "Karnataka", "Delhi"],
+}
+
+@fastdash
+def pick_state(
+    country: str = list(countries),
+    state: str = depends_on("country", lambda c: countries[c]),
+) -> str:
+    return f"{state}, {country}"
+```
+
+The first argument to `depends_on` is the **parameter name** of the parent input. The second is a **resolver** function that receives the parent's current value and returns one of:
+
+- a **list** — sets the dependent dropdown's options and clears its value;
+- a **dict** like `{"data": [...], "value": ...}` — sets either or both;
+- a **scalar** — sets just the dependent's value (e.g. derived numbers, prefilled text).
+
+If the resolver raises an exception, no update fires. Chains work: `A → B → C` is just two `depends_on` declarations.
+
+## 6. Selecting other configurations
 
 Finally, customize your app by controlling various options like the theme of the app, social media branding links, subheaders, deployment mode and so on.
 

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -32,6 +32,7 @@ from .utils import (
     _pil_to_b64,
     _get_default_property,
     _parse_docstring_as_markdown,
+    depends_on,
 )
 
 
@@ -1247,8 +1248,20 @@ def _infer_input_components(func):
         hint = value.annotation
         default = None if value.default == inspect._empty else value.default
 
-        component = _get_component_from_input(hint, default)
-        components.append(component)
+        # Handle depends_on defaults — reactive input wired to a parent input
+        if isinstance(default, depends_on):
+            dep = default
+            component = Fastify(
+                dmc.Select(placeholder="Select..."),
+                "value",
+                tag="Text",
+            )
+            component._depends_on_parent = dep.parent
+            component._depends_on_resolver = dep.resolver
+            components.append(component)
+        else:
+            component = _get_component_from_input(hint, default)
+            components.append(component)
 
     return components
 

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -1197,6 +1197,25 @@ def _get_output_components(_hint_type):
         return resolved.component
     _hint_type = resolved.base_type
 
+    # Resolve string annotations (e.g. "plotly.graph_objects.Figure")
+    if isinstance(_hint_type, str):
+        _graph_hints = {
+            "plotly.graph_objects.Figure", "plotly.graph_objs.Figure",
+            "go.Figure", "Figure",
+        }
+        _df_hints = {"pd.DataFrame", "DataFrame", "pandas.DataFrame"}
+        _img_hints = {"PIL.Image.Image", "Image"}
+        if _hint_type in _graph_hints:
+            return Fastify(
+                component=dcc.Graph(style=dict(height="100%", width="100%")),
+                component_property="figure",
+                tag="Graph",
+            )
+        elif _hint_type in _df_hints:
+            _hint_type = pd.DataFrame
+        elif _hint_type in _img_hints:
+            _hint_type = PIL.Image.Image
+
     # If hint is not type, assume that the user specified an object. Change it to type
     if not isinstance(_hint_type, type):
         _hint_type = type(_hint_type)
@@ -1308,6 +1327,48 @@ ColorInput = Fastify(
         value="#1c7ed6",
     ),
     component_property="value",
+    tag="Text",
+)
+
+MultiSelect = Fastify(
+    component=dmc.MultiSelect(
+        placeholder="Select options",
+    ),
+    component_property="value",
+    tag="Text",
+)
+
+DateRange = Fastify(
+    component=dmc.DatePickerInput(
+        placeholder="Pick date range",
+        type="range",
+        valueFormat="YYYY-MM-DD",
+    ),
+    component_property="value",
+    tag="Text",
+)
+
+Switch = Fastify(
+    component=dmc.Switch(
+        label="Toggle",
+    ),
+    component_property="checked",
+    tag="Bool",
+)
+
+PasswordInput = Fastify(
+    component=dmc.PasswordInput(
+        placeholder="Enter password",
+    ),
+    component_property="value",
+    tag="Text",
+)
+
+Markdown = Fastify(
+    component=dcc.Markdown(
+        style={"padding": "10px"},
+    ),
+    component_property="children",
     tag="Text",
 )
 

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -13,6 +13,11 @@ from fast_dash.Components import (
     NumberInput,
     DateInput,
     ColorInput,
+    MultiSelect,
+    DateRange,
+    Switch,
+    PasswordInput,
+    Markdown,
     Upload,
     UploadImage,
     acknowledge_image_component,
@@ -28,12 +33,14 @@ from fast_dash.Components import (
 import dash
 from dash import Output, Input, State, callback, no_update
 from fast_dash.fast_dash import FastDash, fastdash, update, notify
-from fast_dash.utils import Fastify
+from fast_dash.utils import Fastify, depends_on, from_step
 
 __all__ = [
     "FastDash",
     "fastdash",
     "Fastify",
+    "depends_on",
+    "from_step",
     "Text",
     "TextArea",
     "Slider",
@@ -53,5 +60,10 @@ __all__ = [
     "NumberInput",
     "DateInput",
     "ColorInput",
+    "MultiSelect",
+    "DateRange",
+    "Switch",
+    "PasswordInput",
+    "Markdown",
     "Table"
 ]

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.2.15"
+__version__ = "0.2.16"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/assets/markdown.css
+++ b/fast_dash/assets/markdown.css
@@ -62,21 +62,29 @@ body {
     background: transparent;
 }
 
-/* --- Table styling --- */
-table {
+/* --- Table styling (scoped to data tables, not Mantine calendars/pickers) --- */
+.dash-table-container table,
+.dash-spreadsheet table,
+.fast-dash-table table {
     border-collapse: collapse;
     width: 100%;
     font-size: 14px;
 }
 
-th:not(.CalendarDay),
-td:not(.CalendarDay) {
+.dash-table-container th,
+.dash-spreadsheet th,
+.fast-dash-table th,
+.dash-table-container td,
+.dash-spreadsheet td,
+.fast-dash-table td {
     padding: 10px 12px;
     text-align: left;
     border-bottom: 1px solid var(--mantine-color-default-border, #e9ecef);
 }
 
-th:not(.CalendarDay) {
+.dash-table-container th,
+.dash-spreadsheet th,
+.fast-dash-table th {
     font-weight: 600;
     font-size: 12px;
     text-transform: uppercase;
@@ -84,13 +92,21 @@ th:not(.CalendarDay) {
     color: var(--mantine-color-dimmed, #868e96);
 }
 
-th:first-child:not(.CalendarDay),
-td:first-child:not(.CalendarDay) {
+.dash-table-container th:first-child,
+.dash-spreadsheet th:first-child,
+.fast-dash-table th:first-child,
+.dash-table-container td:first-child,
+.dash-spreadsheet td:first-child,
+.fast-dash-table td:first-child {
     padding-left: 0;
 }
 
-th:last-child:not(.CalendarDay),
-td:last-child:not(.CalendarDay) {
+.dash-table-container th:last-child,
+.dash-spreadsheet th:last-child,
+.fast-dash-table th:last-child,
+.dash-table-container td:last-child,
+.dash-spreadsheet td:last-child,
+.fast-dash-table td:last-child {
     padding-right: 0;
 }
 

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -739,6 +739,84 @@ class FastDash:
             if c.tag == "Download":
                 self._register_download_callback(c.id)
 
+        # Wire depends_on callbacks
+        self._register_depends_on_callbacks()
+
+    def _register_depends_on_callbacks(self, prefix=""):
+        """Register callbacks for inputs that use depends_on."""
+        # Build a parameter-name → component lookup. Component ids are
+        # "input_<param_name>" (optionally prefixed), so strip both the
+        # shared prefix and the "input_" marker.
+        name_to_component = {}
+        for inp in self.inputs_with_ids:
+            key = inp.id
+            if prefix and key.startswith(prefix):
+                key = key[len(prefix):]
+            if key.startswith("input_"):
+                key = key[len("input_"):]
+            name_to_component[key] = inp
+
+        for inp in self.inputs_with_ids:
+            if not hasattr(inp, "_depends_on_parent"):
+                continue
+
+            parent_name = inp._depends_on_parent
+            resolver = inp._depends_on_resolver
+            parent_component = name_to_component.get(parent_name)
+
+            if parent_component is None:
+                warnings.warn(
+                    f"depends_on: parent '{parent_name}' not found in function parameters. "
+                    f"Available: {list(name_to_component.keys())}"
+                )
+                continue
+
+            self._register_single_dependency(
+                parent_component.id,
+                parent_component.component_property,
+                inp.id,
+                resolver,
+            )
+
+    @staticmethod
+    def _apply_dependency_resolver(resolver, parent_value):
+        """Apply a depends_on resolver and map the result to (data, value).
+
+        Pure helper, extracted so tests can exercise the resolver contract
+        without needing a Dash request context. Returns ``(data, value)``
+        where each slot is either a concrete update or ``dash.no_update``.
+        """
+        import dash as _dash
+
+        if parent_value is None:
+            return _dash.no_update, _dash.no_update
+
+        try:
+            result = resolver(parent_value)
+        except Exception:
+            return _dash.no_update, _dash.no_update
+
+        if isinstance(result, list):
+            return result, None
+
+        if isinstance(result, dict):
+            data = result.get("data", _dash.no_update)
+            value = result.get("value", _dash.no_update)
+            return data, value
+
+        return _dash.no_update, result
+
+    def _register_single_dependency(self, parent_id, parent_prop, dependent_id, resolver):
+        """Register a single dependency callback between two inputs."""
+        @self.app.callback(
+            Output(dependent_id, "data"),
+            Output(dependent_id, "value"),
+            Input(parent_id, parent_prop),
+            prevent_initial_call=False,
+        )
+        def update_dependent(parent_value):
+            return self._apply_dependency_resolver(resolver, parent_value)
+
     def _register_download_callback(self, component_id, prefix=""):
         """Register a clientside callback that triggers dcc.Download on button click."""
         store_id = f"{component_id}_download_store"

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -100,7 +100,7 @@ class FastDash:
 
     def __init__(
         self,
-        callback_fn,
+        callback_fn=None,
         mosaic=None,
         inputs=None,
         outputs=None,
@@ -210,6 +210,13 @@ class FastDash:
         # Detect pipeline (steps) mode
         self.is_steps = steps is not None
         self.steps = steps
+
+        # callback_fn is required unless steps= is provided
+        if callback_fn is None and not self.is_steps:
+            raise TypeError(
+                "FastDash requires either `callback_fn` (a function or list of "
+                "functions) or `steps` (a list of step functions). Got neither."
+            )
 
         # Detect multi-function mode (suppressed if steps mode is active)
         self.is_multi = isinstance(callback_fn, list) and not self.is_steps

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -923,77 +923,85 @@ class FastDash:
         self.app.layout = app_layout.generate_layout(stream_event_names=streaming_components)
 
     def _set_multi_layout(self):
-        """Build a tabbed layout for multi-function mode."""
-        from dash_iconify import DashIconify as _DashIconify
-        from dash import dcc as _dcc
+        """Build a tabbed layout for multi-function mode using AppLayout.
 
-        tabs = []
+        Reuses ``AppLayout`` for the surrounding chrome (header, theme,
+        sidebar shell, dark-mode toggle, About modal, footer). Each tab
+        gets its own input panel (rendered in the navbar) and its own
+        output panel (rendered in the main pane). A ``dmc.Tabs`` strip
+        sits at the top of the main pane and drives a callback that
+        toggles the visibility of the per-tab panels.
+        """
+        from .Components import AppLayout
+
         all_streaming_components = ["notification-container"]
+        tab_titles_resolved = []
 
+        # Build per-tab input panels (one Div per tab; only the active
+        # one is shown).
+        per_tab_input_panels = []
         for idx, fd in enumerate(self.func_data):
             prefix = fd["prefix"]
-            input_groups = _make_input_groups(fd["inputs_with_ids"], fd["update_live"], prefix=prefix)
-            output_groups = _make_output_groups(fd["outputs_with_ids"], fd["update_live"], prefix=prefix)
+            input_groups = _make_input_groups(
+                fd["inputs_with_ids"], fd["update_live"], prefix=prefix
+            )
 
-            # Tab title and subtitle from function
             if self.tab_titles and idx < len(self.tab_titles):
                 tab_title = self.tab_titles[idx]
             else:
                 tab_title = re.sub("[^0-9a-zA-Z]+", " ", fd["fn"].__name__).title()
+            tab_titles_resolved.append(tab_title)
 
-            fn_subtitle = _parse_docstring_as_markdown(
-                fd["fn"], title=tab_title, get_short=True
+            per_tab_input_panels.append(
+                dash_html.Div(
+                    [dmc.Stack(children=input_groups, gap="lg")],
+                    id=f"{prefix}input-panel",
+                    style={"display": "block" if idx == 0 else "none"},
+                )
             )
 
-            # Per-tab header (title + subtitle)
-            tab_header_children = [
-                dbc.Row(
-                    dash_html.H2(tab_title, style={"textAlign": "center"}),
-                    style={"padding": "1% 0% 0% 0%"},
-                ),
-            ]
+        sidebar_payload = dmc.ScrollArea(
+            dmc.Stack(per_tab_input_panels, gap="md", id="multi-input-wrapper"),
+            style={"height": "100%"},
+            id="input-group-wrapper",
+        )
+
+        # Build per-tab output panels (one Div per tab; only the active
+        # one is shown). Each panel includes its own loading overlay so
+        # the per-function callbacks can target it by prefix.
+        per_tab_output_panels = []
+        for idx, fd in enumerate(self.func_data):
+            prefix = fd["prefix"]
+            output_groups = _make_output_groups(
+                fd["outputs_with_ids"], fd["update_live"], prefix=prefix
+            )
+
+            fn_subtitle = _parse_docstring_as_markdown(
+                fd["fn"], title=tab_titles_resolved[idx], get_short=True
+            )
+
+            panel_children = []
             if fn_subtitle:
-                tab_header_children.append(
-                    dbc.Row(
-                        dash_html.H5(fn_subtitle, style={"textAlign": "center", "color": "#666"}),
-                        style={"padding": "0% 0% 1% 0%"},
-                    )
+                panel_children.append(
+                    dmc.Text(fn_subtitle, size="sm", c="dimmed",
+                              style={"paddingBottom": "12px"})
                 )
+            panel_children.append(
+                dmc.LoadingOverlay(
+                    id=f"{prefix}loading-overlay",
+                    loaderProps=dict(type=self.loader) if self.loader else {},
+                )
+            )
+            panel_children.append(dash_html.Div(output_groups))
 
-            tab_header = dbc.Container(tab_header_children)
+            per_tab_output_panels.append(
+                dash_html.Div(
+                    panel_children,
+                    id=f"{prefix}output-panel",
+                    style={"display": "block" if idx == 0 else "none"},
+                )
+            )
 
-            # Build sidebar-style content for this tab
-            tab_content = dbc.Row([
-                dbc.Col(
-                    children=[dmc.Stack(children=input_groups)],
-                    id=f"{prefix}input-group",
-                    xs=12, md=2,
-                    style={
-                        "background-color": "#F5F7F7",
-                        "display": "block",
-                        "padding": "2% 20px 0 20px",
-                        "height": f"{self.scale_height * 80}vh",
-                    },
-                    class_name="border border-right",
-                ),
-                dbc.Col([
-                    tab_header,
-                    dmc.LoadingOverlay(
-                        id=f"{prefix}loading-overlay",
-                        loaderProps=dict(type=self.loader) if self.loader else {},
-                    ),
-                    dash_html.Div(id=f"{prefix}dummy-div", style={"display": "none"}),
-                    dbc.Col(
-                        output_groups,
-                        class_name="g-1 d-flex flex-fill flex-column",
-                        style={"height": f"{self.scale_height * 65}vh"},
-                    ),
-                ], style={"padding": "1% 2% 0 2%"}),
-            ], class_name="d-flex")
-
-            tabs.append(dbc.Tab(tab_content, label=tab_title, tab_id=f"tab-{idx}"))
-
-            # Collect streaming components
             for c in fd["outputs_with_ids"]:
                 if getattr(c, "stream", False):
                     all_streaming_components.append(c.id)
@@ -1001,81 +1009,60 @@ class FastDash:
                         for i in range(getattr(c, "stream_limit", 10)):
                             all_streaming_components.append(f"{c.id}_{i + 1}_response")
 
-        tabs_component = dbc.Tabs(tabs, id="multi-function-tabs", active_tab="tab-0")
+        # Tabs strip across the top of the main pane.
+        tabs_strip = dmc.Tabs(
+            [
+                dmc.TabsList(
+                    [
+                        dmc.TabsTab(t, value=f"tab-{i}")
+                        for i, t in enumerate(tab_titles_resolved)
+                    ]
+                )
+            ],
+            value="tab-0",
+            id="multi-function-tabs",
+            style={"marginBottom": "16px"},
+        )
 
-        # Build navbar
-        navbar_components = []
-        if self.about:
-            navbar_components.append(
-                dbc.NavLink("About", id="about-navlink",
-                            style={"cursor": "pointer", "color": "white"})
-            )
+        main_payload = dash_html.Div(
+            [
+                tabs_strip,
+                dash_html.Div(per_tab_output_panels, id="multi-output-wrapper"),
+            ]
+        )
 
-        social_links = []
-        if self.github_url:
-            social_links.append(
-                dbc.NavLink(dash_html.I(className="fab fa-github fa-lg"),
-                            href=self.github_url, target="_blank")
-            )
-        if self.linkedin_url:
-            social_links.append(
-                dbc.NavLink(dash_html.I(className="fab fa-linkedin fa-lg"),
-                            href=self.linkedin_url, target="_blank")
-            )
-        if self.twitter_url:
-            social_links.append(
-                dbc.NavLink(dash_html.I(className="fab fa-twitter fa-lg"),
-                            href=self.twitter_url, target="_blank")
-            )
-        navbar_components.extend(social_links)
+        # Subclass AppLayout to inject our pre-built sidebar / main content.
+        class _MultiLayout(AppLayout):
+            def generate_input_component(self_inner):
+                return sidebar_payload
 
-        app_navbar = dbc.NavbarSimple(
-            children=navbar_components,
-            brand=self.title or "",
-            color="primary",
-            dark=True,
-            fluid=True,
-            expand=True,
-            style={"padding": "0 0 0 0"},
-        ) if self.navbar and not self.minimal else dash_html.Div()
+            def generate_output_component(self_inner):
+                return main_payload
 
-        # About modal
-        about_modal = dbc.Modal(
-            id="about-modal", is_open=False, size="lg",
-        ) if self.about else dash_html.Div(id="about-modal", style={"display": "none"})
-
-        # Footer (rocket icon)
-        if self.branding and self.footer and not self.minimal:
-            footer = dmc.Affix(
-                dmc.Tooltip(
-                    label="Made with Fast Dash!",
-                    position="top",
-                    withArrow=True,
-                    transitionProps={"duration": 300},
-                    children=_dcc.Link(
-                        dmc.Button(
-                            _DashIconify(icon="ion:rocket-sharp", width=20), radius=500
-                        ),
-                        href="https://github.com/dkedar7/fast_dash",
-                        target="_blank",
-                    ),
-                ),
-                position={"bottom": "20px", "right": "20px"},
-            )
-        else:
-            footer = dash_html.Div()
-
-        self.app.layout = dmc.MantineProvider([
-            dmc.NotificationContainer(id="notification-container", position="bottom-right"),
-            dash_html.Div(id="dummy-div", style={"display": "none"}),
-            dbc.Container([
-                dbc.Row([app_navbar], style={"padding": "0 0 0 0"}),
-                about_modal,
-                tabs_component,
-                footer,
-                DashSocketIO(id="socketio", eventNames=all_streaming_components) if self.stream else dash_html.Div(id="socketio", style={"display": "none"}),
-            ], fluid=True, style={"height": "100vh", "width": "100%"}),
-        ])
+        layout_args = {
+            "mosaic": "A",
+            "inputs": [],
+            "outputs": [per_tab_output_panels[0]],
+            "title": self.title,
+            "title_image_path": self.title_image_path,
+            "subtitle": self.subtitle,
+            "github_url": self.github_url,
+            "linkedin_url": self.linkedin_url,
+            "twitter_url": self.twitter_url,
+            "navbar": self.navbar,
+            "footer": self.footer,
+            "loader": self.loader,
+            "branding": self.branding,
+            "about": self.about,
+            "minimal": self.minimal,
+            "scale_height": self.scale_height,
+            "theme": self.theme,
+            "app": self,
+        }
+        self.layout_object = _MultiLayout(**layout_args)
+        self.app.layout = self.layout_object.generate_layout(
+            stream_event_names=all_streaming_components,
+        )
 
     def register_callback_fn(self):
         if self.is_multi:
@@ -1307,27 +1294,83 @@ class FastDash:
         for idx, fd in enumerate(self.func_data):
             self._register_fn_callback(idx, fd)
 
-        # About modal callback
+        # Tab switcher: toggle visibility of per-tab input/output panels.
+        n_tabs = len(self.func_data)
+        prefixes = [fd["prefix"] for fd in self.func_data]
+
+        @self.app.callback(
+            [Output(f"{p}input-panel", "style") for p in prefixes]
+            + [Output(f"{p}output-panel", "style") for p in prefixes],
+            Input("multi-function-tabs", "value"),
+        )
+        def _switch_tabs(active):
+            try:
+                active_idx = int(str(active).replace("tab-", ""))
+            except (TypeError, ValueError):
+                active_idx = 0
+            input_styles = [
+                {"display": "block" if i == active_idx else "none"}
+                for i in range(n_tabs)
+            ]
+            output_styles = list(input_styles)
+            return input_styles + output_styles
+
+        # Layout chrome callbacks (sidebar burger, dark mode). The About
+        # modal callback inside AppLayout.callbacks() is unsafe in multi
+        # mode because it expects a single callback_fn, so we register
+        # only the chrome bits and supply our own About callback below.
+        if not self.minimal:
+            self._register_multi_chrome_callbacks()
+
+        # About modal callback (combined docstrings across all functions).
         if self.about and not self.minimal:
             @self.app.callback(
-                Output("about-modal", "is_open"),
+                Output("about-modal", "opened"),
                 Output("about-modal", "children"),
                 Input("about-navlink", "n_clicks"),
-                State("about-modal", "is_open"),
+                State("about-modal", "opened"),
                 prevent_initial_call=True,
             )
-            def toggle_about(n_clicks, is_open):
+            def toggle_about(n_clicks, opened):
                 if n_clicks:
+                    from dash import dcc
                     sections = []
                     for fd_ in self.func_data:
                         fn = fd_["fn"]
                         fn_title = re.sub("[^0-9a-zA-Z]+", " ", fn.__name__).title()
                         about_text = _parse_docstring_as_markdown(fn, title=fn_title)
-                        from dash import dcc
                         sections.append(dcc.Markdown(about_text))
                         sections.append(dash_html.Hr())
-                    return not is_open, dash_html.Div(sections[:-1])  # Remove trailing Hr
+                    return not opened, dash_html.Div(sections[:-1])
                 raise PreventUpdate
+
+    def _register_multi_chrome_callbacks(self):
+        """Wire dark-mode toggle + sidebar burger for multi-function mode.
+
+        Mirrors the relevant bits of ``AppLayout.callbacks`` but skips the
+        single-function About modal handler (we register our own).
+        """
+        self.app.clientside_callback(
+            """
+            function(checked) {
+                return checked ? "dark" : "light";
+            }
+            """,
+            Output("mantine-provider", "forceColorScheme"),
+            Input("theme-toggle", "checked"),
+        )
+
+        @self.app.callback(
+            Output("appshell", "navbar"),
+            Input("sidebar-button", "opened"),
+        )
+        def _toggle_sidebar(opened):
+            collapsed = {"mobile": not opened, "desktop": not opened}
+            return {
+                "width": 300,
+                "breakpoint": "sm",
+                "collapsed": collapsed,
+            }
 
     def _register_fn_callback(self, idx, fd):
         """Register callbacks for a single function in multi-function mode."""

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -11,7 +11,7 @@ import json
 import dash
 import flask
 from flask_socketio import SocketIO, emit
-from dash import Input, Output, State, ctx, clientside_callback
+from dash import Input, Output, State, ctx, clientside_callback, dcc
 from dash.exceptions import PreventUpdate
 from dash_socketio import DashSocketIO
 
@@ -37,6 +37,7 @@ from .utils import (
     _infer_variable_names,
     _parse_docstring_as_markdown,
     _get_error_notification_component,
+    from_step,
 )
 
 import contextvars
@@ -91,6 +92,12 @@ class FastDash:
     sets all parameters required for Fast Dash app deployment.
     """
 
+    # Per-process cache for step-pipeline outputs, keyed by browser session id.
+    # Each session maps {step_index: result_value} so downstream from_step
+    # parameters can resolve. Note: this is process-global; a server restart
+    # or multi-worker deploy will lose state. Acceptable for prototyping.
+    _step_cache = {}
+
     def __init__(
         self,
         callback_fn,
@@ -119,6 +126,7 @@ class FastDash:
         scale_height=1,
         run_kwargs=dict(),
         tab_titles=None,
+        steps=None,
         **kwargs
     ):
         """
@@ -193,11 +201,24 @@ class FastDash:
 
             tab_titles (list of str, optional): Tab titles when ``callback_fn`` is a list of functions. \
                 If None, tab titles are derived from the function names. Ignored for single-function apps. Defaults to None.
+
+            steps (list of funcs, optional): A linear pipeline of step functions. Each step gets its own \
+                page in a stepper UI; outputs of earlier steps can feed downstream steps via ``from_step``. \
+                When provided, ``callback_fn`` is ignored. Defaults to None.
         """
 
-        # Detect multi-function mode
-        self.is_multi = isinstance(callback_fn, list)
-        if self.is_multi:
+        # Detect pipeline (steps) mode
+        self.is_steps = steps is not None
+        self.steps = steps
+
+        # Detect multi-function mode (suppressed if steps mode is active)
+        self.is_multi = isinstance(callback_fn, list) and not self.is_steps
+
+        if self.is_steps:
+            callback_fn = steps[0]  # Use first step for shared chrome
+            self.callback_fns = list(steps)
+            self.tab_titles = None
+        elif self.is_multi:
             self.callback_fns = callback_fn
             self.tab_titles = tab_titles
             callback_fn = callback_fn[0]  # Use first function for shared chrome
@@ -274,7 +295,9 @@ class FastDash:
         self.output_labels = output_labels
         self.update_live = update_live
 
-        if self.is_multi:
+        if self.is_steps:
+            self._init_steps()
+        elif self.is_multi:
             self._init_multi_function()
         else:
             self._init_single_function(callback_fn, inputs, outputs, output_labels, update_live)
@@ -396,6 +419,442 @@ class FastDash:
         self.set_layout()
         self.register_callback_fn()
         self.add_streaming()
+
+    def _init_steps(self):
+        """Initialize a linear multi-step pipeline app.
+
+        For each step, separate parameters that take their value from a
+        previous step (``from_step``) from parameters the user provides
+        through the UI. Build component metadata for each step the same
+        way single-function apps do, then hand off to the layout and
+        callback registration.
+        """
+        import inspect as _inspect
+
+        self.step_data = []
+        self.fn_to_idx = {}
+
+        for idx, fn in enumerate(self.steps):
+            self.fn_to_idx[fn] = idx
+            sig = _inspect.signature(fn)
+            prefix = f"step{idx}_"
+
+            # Split params into wired-from-cache vs user-facing
+            from_step_params = {}
+            user_params = []
+            for pname, pobj in sig.parameters.items():
+                default = (None if pobj.default == _inspect.Parameter.empty
+                           else pobj.default)
+                if isinstance(default, from_step):
+                    from_step_params[pname] = default
+                else:
+                    user_params.append((pname, pobj))
+
+            # Build a synthetic function whose signature contains only the
+            # user-facing parameters, so the existing component-inference
+            # pipeline works unchanged.
+            if user_params:
+                user_fn = self._make_user_params_fn(user_params)
+                fn_inputs = _infer_input_components(user_fn)
+            else:
+                user_fn = lambda: None
+                fn_inputs = []
+
+            # Use a deterministic output label per step (avoids the inferred
+            # label bug when a step has multiple visible outputs).
+            step_title = re.sub("[^0-9a-zA-Z]+", " ", fn.__name__).title()
+            fn_output_labels = [step_title + " Output"]
+            fn_outputs = _infer_output_components(fn, None, fn_output_labels)
+
+            inputs_with_ids = _assign_ids_to_inputs(fn_inputs, user_fn, prefix=prefix)
+            outputs_with_ids = _assign_ids_to_outputs(fn_outputs, fn, prefix=prefix)
+
+            step_desc = _parse_docstring_as_markdown(fn, title=step_title, get_short=True)
+
+            self.step_data.append({
+                "fn": fn,
+                "idx": idx,
+                "prefix": prefix,
+                "title": step_title,
+                "description": step_desc or "",
+                "from_step_params": from_step_params,
+                "user_params": user_params,
+                "inputs": fn_inputs,
+                "outputs": fn_outputs,
+                "input_tags": [inp.tag for inp in fn_inputs],
+                "output_tags": [out.tag for out in fn_outputs],
+                "inputs_with_ids": inputs_with_ids,
+                "outputs_with_ids": outputs_with_ids,
+            })
+
+        # Set references for backward compat with single-function plumbing
+        self.inputs_with_ids = self.step_data[0]["inputs_with_ids"]
+        self.outputs_with_ids = self.step_data[0]["outputs_with_ids"]
+
+        self.app.title = self.title or ""
+        self._set_steps_layout()
+        self._register_steps_callbacks()
+
+    @staticmethod
+    def _make_user_params_fn(user_params):
+        """Create a synthetic function with only the user-visible parameters.
+
+        ``_infer_input_components`` reads ``inspect.signature(fn)`` to decide
+        what UI components to build. For step functions, we want to skip
+        parameters wired via ``from_step`` (those don't get UI). This helper
+        rebuilds a fresh signature containing only the user-facing params,
+        and returns a no-op function carrying it.
+        """
+        import inspect as _inspect
+
+        params = []
+        annotations = {}
+        for pname, pobj in user_params:
+            params.append(_inspect.Parameter(
+                pname,
+                kind=_inspect.Parameter.POSITIONAL_OR_KEYWORD,
+                default=pobj.default,
+                annotation=pobj.annotation,
+            ))
+            if pobj.annotation != _inspect.Parameter.empty:
+                annotations[pname] = pobj.annotation
+
+        def _user_fn(**kwargs):
+            pass
+
+        _user_fn.__signature__ = _inspect.Signature(params)
+        _user_fn.__annotations__ = annotations
+        _user_fn.__name__ = "user_params"
+        return _user_fn
+
+    def _set_steps_layout(self):
+        """Build the multi-step pipeline layout.
+
+        Reuses ``AppLayout`` for the surrounding chrome (header, theme,
+        sidebar, dark-mode toggle, footer) by subclassing it and overriding
+        the input and output region builders. Only the per-step content is
+        steps-specific; everything else is shared with single-function apps.
+        """
+        from .Components import AppLayout
+
+        # Build the per-step input containers (one Div per step, only the
+        # active one is shown). Steps with no user inputs render a small
+        # "no inputs needed" hint.
+        step_input_containers = []
+        for i, sd in enumerate(self.step_data):
+            prefix = sd["prefix"]
+            if sd["inputs_with_ids"]:
+                input_groups = _make_input_groups(
+                    sd["inputs_with_ids"], False, prefix=prefix, show_submit=False
+                )
+            else:
+                input_groups = [dmc.Text("No inputs needed for this step.",
+                                          c="dimmed", size="sm")]
+            step_input_containers.append(
+                dash_html.Div(
+                    [
+                        dmc.Text(sd["title"], fw=600, size="sm",
+                                  style={"paddingBottom": "8px"}),
+                        dmc.Stack(children=input_groups, gap="lg"),
+                    ],
+                    id=f"step-inputs-{i}",
+                    style={"display": "block" if i == 0 else "none"},
+                )
+            )
+
+        # Run / Back / Next buttons
+        run_btn = dmc.Button(
+            "Run", id="step-run-btn", fullWidth=True, size="sm",
+            style={"marginTop": "16px"},
+        )
+        nav_group = dmc.Group(
+            [
+                dmc.Button("Back", id="step-back-btn", variant="light",
+                            size="sm", disabled=True),
+                dmc.Button("Next", id="step-next-btn", variant="filled",
+                            size="sm", disabled=True),
+            ],
+            justify="space-between",
+            style={"marginTop": "12px"},
+        )
+
+        sidebar_payload = dmc.Stack(
+            [dash_html.Div(step_input_containers, id="step-inputs-wrapper"),
+             run_btn, nav_group],
+            gap="md",
+        )
+
+        # Build the per-step output containers
+        step_output_containers = []
+        for i, sd in enumerate(self.step_data):
+            prefix = sd["prefix"]
+            if sd["outputs_with_ids"]:
+                output_content = _make_output_groups(
+                    sd["outputs_with_ids"], False, prefix=prefix
+                )
+            else:
+                output_content = []
+            step_output_containers.append(
+                dash_html.Div(
+                    output_content,
+                    id=f"step-outputs-{i}",
+                    style={"display": "block" if i == 0 else "none"},
+                )
+            )
+
+        # Stepper progress indicator above the per-step output area
+        stepper_steps = [
+            dmc.StepperStep(
+                label=sd["title"],
+                description=(sd["description"] or "")[:50],
+            )
+            for sd in self.step_data
+        ]
+        stepper_steps.append(
+            dmc.StepperCompleted(
+                children=dmc.Text("All steps complete!", c="green", fw=500)
+            )
+        )
+        stepper = dmc.Stepper(
+            id="pipeline-stepper",
+            active=0,
+            children=stepper_steps,
+            allowNextStepsSelect=False,
+            color="blue",
+            size="sm",
+            style={"padding": "0 0 16px 0"},
+        )
+
+        loading_overlay = dmc.LoadingOverlay(
+            id="loading-overlay",
+            loaderProps=dict(type=self.loader) if self.loader else {},
+        )
+
+        main_payload = dash_html.Div(
+            [
+                stepper,
+                loading_overlay,
+                dash_html.Div(step_output_containers, id="step-outputs-wrapper"),
+            ]
+        )
+
+        # Subclass AppLayout to inject our pre-built sidebar / main content
+        # while keeping all the standard chrome.
+        class _StepsLayout(AppLayout):
+            def generate_input_component(self_inner):
+                return dmc.ScrollArea(
+                    sidebar_payload,
+                    style={"height": "100%"},
+                    id="input-group-wrapper",
+                )
+
+            def generate_output_component(self_inner):
+                return main_payload
+
+        # Instantiate with empty inputs/outputs (we overrode the methods)
+        # and a benign mosaic so the parent's __init__ doesn't try to infer one.
+        layout_args = {
+            "mosaic": "A",
+            "inputs": [],
+            "outputs": [step_output_containers[0]],  # at least one element
+            "title": self.title,
+            "title_image_path": self.title_image_path,
+            "subtitle": self.subtitle,
+            "github_url": self.github_url,
+            "linkedin_url": self.linkedin_url,
+            "twitter_url": self.twitter_url,
+            "navbar": self.navbar,
+            "footer": self.footer,
+            "loader": self.loader,
+            "branding": self.branding,
+            "about": self.about,
+            "minimal": self.minimal,
+            "scale_height": self.scale_height,
+            "theme": self.theme,
+            "app": self,
+        }
+        self.layout_object = _StepsLayout(**layout_args)
+        # Stores for step state — appended after AppShell so they're not
+        # inside the navbar/main scroll regions.
+        self.app.layout = self.layout_object.generate_layout(
+            stream_event_names=["notification-container"],
+        )
+        # Add Dash stores to the layout's children
+        self.app.layout.children.extend([
+            dcc.Store(id="step-session-id", storage_type="session"),
+            dcc.Store(id="step-current-idx", data=0),
+            dcc.Store(id="step-completed-set", data=[]),
+        ])
+
+    def _register_steps_callbacks(self):
+        """Register callbacks for the step pipeline: session init, run, next, back, visibility."""
+        import uuid as _uuid
+
+        total_steps = len(self.step_data)
+
+        # ---- Session init: assign a UUID per browser session on first load ----
+        @self.app.callback(
+            Output("step-session-id", "data"),
+            Input("step-session-id", "data"),
+        )
+        def init_session(current_id):
+            if current_id:
+                return current_id
+            sid = str(_uuid.uuid4())
+            FastDash._step_cache[sid] = {}
+            return sid
+
+        # ---- Layout chrome callbacks (dark mode, sidebar, about) ----
+        if not self.minimal:
+            self.layout_object.callbacks(self)
+
+        # ---- Run: execute the current step ----
+        all_output_targets = []
+        for sd in self.step_data:
+            for out in sd["outputs_with_ids"]:
+                all_output_targets.append(
+                    Output(out.id, out.component_property, allow_duplicate=True)
+                )
+
+        all_input_sources = []
+        for sd in self.step_data:
+            for inp in sd["inputs_with_ids"]:
+                all_input_sources.append(State(inp.id, inp.component_property))
+
+        @self.app.callback(
+            all_output_targets + [
+                Output("notification-container", "sendNotifications", allow_duplicate=True),
+                Output("loading-overlay", "visible", allow_duplicate=True),
+                Output("step-completed-set", "data", allow_duplicate=True),
+            ],
+            Input("step-run-btn", "n_clicks"),
+            [State("step-current-idx", "data"),
+             State("step-session-id", "data"),
+             State("step-completed-set", "data")] + all_input_sources,
+            prevent_initial_call=True,
+            running=[(Output("step-run-btn", "disabled"), True, False)],
+        )
+        def run_step(n_clicks, current_idx, session_id, completed_set, *input_values):
+            if not n_clicks or session_id is None:
+                raise PreventUpdate
+
+            sd = self.step_data[current_idx]
+            fn = sd["fn"]
+            kwargs = {}
+
+            cache = FastDash._step_cache.setdefault(session_id, {})
+
+            # 1) Inject from_step values from cache
+            for pname, fs in sd["from_step_params"].items():
+                source_idx = self.fn_to_idx.get(fs.source_fn)
+                if source_idx is None or source_idx not in cache:
+                    notification = _get_error_notification_component(
+                        f"Step '{sd['title']}' depends on a previous step that hasn't been run yet."
+                    )
+                    return ([dash.no_update] * len(all_output_targets)
+                            + [notification, False, completed_set])
+                cached_val = cache[source_idx]
+                kwargs[pname] = fs.transform(cached_val) if fs.transform else cached_val
+
+            # 2) Slice the relevant input values out of the flat tuple
+            input_offset = sum(
+                len(s["inputs_with_ids"])
+                for s in self.step_data[:current_idx]
+            )
+            user_input_vals = list(input_values[
+                input_offset:input_offset + len(sd["inputs_with_ids"])
+            ])
+            user_input_vals = _transform_inputs(user_input_vals, sd["input_tags"])
+            for (pname, _pobj), val in zip(sd["user_params"], user_input_vals):
+                kwargs[pname] = val
+
+            # 3) Execute and cache the result
+            try:
+                result = fn(**kwargs)
+            except Exception as e:
+                traceback.print_exc()
+                notification = _get_error_notification_component(str(e))
+                return ([dash.no_update] * len(all_output_targets)
+                        + [notification, False, completed_set])
+            cache[current_idx] = result
+
+            # 4) Transform outputs for display
+            output_vals = list(result) if isinstance(result, tuple) else [result]
+            output_vals = _transform_outputs(
+                output_vals, sd["output_tags"], sd["outputs_with_ids"], 0
+            )
+
+            # 5) Build the full output array (no_update for non-active steps)
+            all_outputs = []
+            for other_sd in self.step_data:
+                if other_sd["idx"] == current_idx:
+                    all_outputs.extend(output_vals)
+                else:
+                    all_outputs.extend([dash.no_update] * len(other_sd["outputs_with_ids"]))
+
+            if current_idx not in completed_set:
+                completed_set = list(completed_set) + [current_idx]
+            return all_outputs + [[], False, completed_set]
+
+        # ---- Next: advance to the next step ----
+        @self.app.callback(
+            Output("step-current-idx", "data", allow_duplicate=True),
+            Output("pipeline-stepper", "active", allow_duplicate=True),
+            Input("step-next-btn", "n_clicks"),
+            State("step-current-idx", "data"),
+            prevent_initial_call=True,
+        )
+        def step_next(n, current_idx):
+            if not n:
+                raise PreventUpdate
+            if current_idx + 1 < total_steps:
+                return current_idx + 1, current_idx + 1
+            return total_steps, total_steps  # Completed
+
+        # ---- Back: rewind one step, clearing downstream cached results ----
+        @self.app.callback(
+            Output("step-current-idx", "data", allow_duplicate=True),
+            Output("pipeline-stepper", "active", allow_duplicate=True),
+            Output("step-completed-set", "data", allow_duplicate=True),
+            Input("step-back-btn", "n_clicks"),
+            State("step-current-idx", "data"),
+            State("step-completed-set", "data"),
+            State("step-session-id", "data"),
+            prevent_initial_call=True,
+        )
+        def step_back(n, current_idx, completed_set, session_id):
+            if not n or current_idx <= 0:
+                raise PreventUpdate
+            cache = FastDash._step_cache.get(session_id, {})
+            for k in [k for k in cache if k >= current_idx]:
+                del cache[k]
+            completed_set = [c for c in completed_set if c < current_idx]
+            return current_idx - 1, current_idx - 1, completed_set
+
+        # ---- Visibility: show the active step's inputs + outputs; toggle nav button states ----
+        visibility_outputs = []
+        for i in range(total_steps):
+            visibility_outputs.append(Output(f"step-inputs-{i}", "style"))
+            visibility_outputs.append(Output(f"step-outputs-{i}", "style"))
+        visibility_outputs.extend([
+            Output("step-back-btn", "disabled"),
+            Output("step-next-btn", "disabled"),
+        ])
+
+        @self.app.callback(
+            visibility_outputs,
+            Input("step-current-idx", "data"),
+            Input("step-completed-set", "data"),
+        )
+        def update_step_visibility(current_idx, completed_set):
+            styles = []
+            for i in range(total_steps):
+                show = "block" if i == current_idx else "none"
+                styles.append({"display": show})  # inputs
+                styles.append({"display": show})  # outputs
+            back_disabled = current_idx == 0
+            next_disabled = current_idx not in (completed_set or [])
+            return styles + [back_disabled, next_disabled]
 
     def run(self):
         self.app.run(**self.run_kwargs) if self.mode is None else self.app.run(

--- a/fast_dash/utils.py
+++ b/fast_dash/utils.py
@@ -23,6 +23,61 @@ import warnings
 import re
 
 
+class from_step:
+    """Declare that a step parameter receives its value from a previous step's output.
+
+    Used in ``FastDash(steps=[...])`` pipelines to wire the output of one step
+    function into a parameter of the next.
+
+    Parameters
+    ----------
+    source_fn : callable
+        The step function whose return value feeds this parameter.
+    transform : callable, optional
+        A function applied to the source output before passing it.
+        Commonly used to derive UI props (e.g. column names from a DataFrame).
+
+    Example::
+
+        def load_data(path: str = "data.csv") -> pd.DataFrame:
+            return pd.read_csv(path)
+
+        def select_columns(
+            data=from_step(load_data),
+            columns: list = MultiSelect,
+        ) -> pd.DataFrame:
+            return data[columns]
+    """
+
+    def __init__(self, source_fn, transform=None):
+        self.source_fn = source_fn
+        self.transform = transform
+
+
+class depends_on:
+    """Declare that an input depends on another input's value.
+
+    The *resolver* callable receives the current value of the parent input
+    and returns property updates for the dependent component:
+
+    - **list** → sets the ``data`` property (dropdown options).
+    - **dict** → sets the specified component properties (e.g. ``min``, ``max``).
+    - **scalar** → sets the component's main ``value``.
+
+    Example::
+
+        def my_app(
+            country: str = ["USA", "India"],
+            state: str = depends_on("country", lambda val: countries[val]),
+        ) -> str:
+            return f"{state}, {country}"
+    """
+
+    def __init__(self, parent: str, resolver):
+        self.parent = parent
+        self.resolver = resolver
+
+
 def Fastify(component, component_property, ack=None, placeholder=None, label_=None, tag=None, stream=False, *args, **kwargs):
     """
     Modify a Dash component into a FastComponent.
@@ -339,7 +394,7 @@ def _assign_ids_to_inputs(inputs, callback_fn, prefix=""):
     return inputs_with_ids
 
 
-def _make_input_groups(inputs_with_ids, update_live, prefix=""):
+def _make_input_groups(inputs_with_ids, update_live, prefix="", show_submit=True):
     input_groups = []
 
     for idx, input_ in enumerate(inputs_with_ids):
@@ -374,21 +429,22 @@ def _make_input_groups(inputs_with_ids, update_live, prefix=""):
             )
         )
 
-    button_row = html.Div(
-        [
-            dmc.Button(
-                "Submit",
-                id=f"{prefix}submit_inputs",
-                n_clicks=0,
-                fullWidth=True,
-            ),
-        ],
-        style={"paddingTop": "8px"}
-        if update_live is False
-        else {"display": "none"},
-    )
+    if show_submit:
+        button_row = html.Div(
+            [
+                dmc.Button(
+                    "Run",
+                    id=f"{prefix}submit_inputs",
+                    n_clicks=0,
+                    fullWidth=True,
+                ),
+            ],
+            style={"paddingTop": "8px"}
+            if update_live is False
+            else {"display": "none"},
+        )
 
-    input_groups.append(button_row)
+        input_groups.append(button_row)
 
     return input_groups
 

--- a/fast_dash/utils.py
+++ b/fast_dash/utils.py
@@ -606,6 +606,38 @@ def _friendly_error_message(error_text):
     if "'nonetype' object is not" in lower and ("subscriptable" in lower or "iterable" in lower):
         return "Your function returned None. Make sure it has a return statement that produces the expected output."
 
+    # Wrong number of arguments
+    if "argument" in lower and ("takes" in lower or "missing" in lower or "unexpected keyword" in lower):
+        return f"Function argument mismatch. {error_text}"
+
+    # Type errors (general)
+    if "typeerror" in lower and "unsupported operand" in lower:
+        return f"Type mismatch in a calculation. Check that your inputs have the correct type. Details: {error_text}"
+
+    # Key errors
+    if "keyerror" in lower:
+        return f"A dictionary key was not found. Details: {error_text}"
+
+    # Value errors
+    if "valueerror" in lower and "could not convert" in lower:
+        return f"A value couldn't be converted to the expected type. Check your input formats. Details: {error_text}"
+
+    # Division by zero
+    if "division by zero" in lower or "zerodivisionerror" in lower:
+        return "Division by zero occurred. Check that your divisor inputs are not zero."
+
+    # Index errors
+    if "index out of range" in lower or "indexerror" in lower:
+        return f"A list index was out of range. Details: {error_text}"
+
+    # JSON / serialization errors
+    if "is not json serializable" in lower:
+        return f"A return value can't be displayed. Make sure your function returns standard Python types (strings, numbers, lists, dicts). Details: {error_text}"
+
+    # Timeout
+    if "timeout" in lower or "timed out" in lower:
+        return "The operation timed out. Try with smaller inputs or check your network connection."
+
     # Chat component format
     if "chat component requires" in lower:
         return error_text  # Already a friendly message
@@ -618,10 +650,22 @@ def _friendly_error_message(error_text):
     if "no such file or directory" in lower or "filenotfounderror" in lower:
         return f"A file could not be found. Details: {error_text}"
 
+    # Permission errors
+    if "permission denied" in lower or "permissionerror" in lower:
+        return f"Permission denied when accessing a resource. Details: {error_text}"
+
     # Import errors
     if "no module named" in lower:
         module = error_text.split("'")[1] if "'" in error_text else "unknown"
         return f"Missing dependency: '{module}'. Install it with: pip install {module}"
+
+    # Connection errors
+    if "connectionerror" in lower or "connection refused" in lower or "urlopen error" in lower:
+        return f"A network connection failed. Check your internet connection or the service URL. Details: {error_text}"
+
+    # Memory errors
+    if "memoryerror" in lower:
+        return "The operation ran out of memory. Try with smaller inputs or data."
 
     # Fallback: capitalize first letter
     return error_text.capitalize() if error_text else "An unexpected error occurred."
@@ -748,6 +792,9 @@ def _get_default_property(component_type):
             dmc.TextInput: "value",
             dmc.Textarea: "value",
             dmc.TimeInput: "value",
+            dmc.DateInput: "value",
+            dmc.DatePickerInput: "value",
+            dmc.PasswordInput: "value",
             dmc.Blockquote: "children",
             dmc.Code: "children",
             dmc.List: "children",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.2.15"
+version = "0.2.16"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_depends_on.py
+++ b/tests/test_depends_on.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+"""Tests for the ``depends_on`` reactive-input helper.
+
+``depends_on`` wires a dependent input's options / value to a parent input's
+value. Resolver return-type semantics:
+
+- **list**   → sets the component's ``data`` (dropdown options), clears value
+- **dict**   → sets ``data`` / ``value`` from the dict
+- **scalar** → sets the component's ``value``
+- **None parent value** → no update
+- **resolver raises** → no update (silently swallowed)
+"""
+import warnings
+
+import dash
+
+from fast_dash import FastDash, depends_on
+from fast_dash.Components import _infer_input_components
+
+
+# --- class contract ---
+
+
+def test_depends_on_stores_parent_and_resolver():
+    resolver = lambda v: [v, v.upper()]
+    d = depends_on("country", resolver)
+    assert d.parent == "country"
+    assert d.resolver is resolver
+
+
+# --- _infer_input_components picks it up ---
+
+
+def test_depends_on_default_produces_select_with_metadata():
+    resolver = lambda v: ["a", "b"]
+
+    def pick(
+        country: str = ["USA"],
+        state: str = depends_on("country", resolver),
+    ) -> str:
+        return state
+
+    comps = _infer_input_components(pick)
+    state_comp = comps[1]
+    assert state_comp.component.__class__.__name__ == "Select"
+    assert state_comp._depends_on_parent == "country"
+    assert state_comp._depends_on_resolver is resolver
+
+
+def test_depends_on_does_not_affect_non_dependent_inputs():
+    def pick(
+        country: str = ["USA"],
+        state: str = depends_on("country", lambda v: ["a"]),
+    ) -> str:
+        return state
+
+    comps = _infer_input_components(pick)
+    country_comp = comps[0]
+    assert not hasattr(country_comp, "_depends_on_parent")
+
+
+# --- FastDash app integration ---
+
+
+def _countries():
+    return {
+        "USA": ["California", "Texas", "New York"],
+        "India": ["Maharashtra", "Karnataka", "Delhi"],
+    }
+
+
+def test_app_builds_with_depends_on():
+    countries = _countries()
+
+    def pick(
+        country: str = list(countries.keys()),
+        state: str = depends_on("country", lambda v: countries[v]),
+    ) -> str:
+        return f"{state}, {country}"
+
+    app = FastDash(callback_fn=pick)
+    assert app.app.layout is not None
+
+
+def test_app_registers_extra_callback_for_dependency():
+    """Registering a depends_on input should add a callback beyond the baseline."""
+    def baseline(country: str = ["USA"]) -> str:
+        return country
+
+    baseline_count = len(FastDash(callback_fn=baseline).app.callback_map)
+
+    def with_dep(
+        country: str = ["USA"],
+        state: str = depends_on("country", lambda v: [v, v.upper()]),
+    ) -> str:
+        return state
+
+    dep_count = len(FastDash(callback_fn=with_dep).app.callback_map)
+    assert dep_count > baseline_count
+
+
+def test_depends_on_unknown_parent_emits_warning():
+    """Invalid parent reference should warn but still build a working app."""
+    def pick(
+        country: str = ["USA"],
+        state: str = depends_on("nonexistent_param", lambda v: [v]),
+    ) -> str:
+        return state
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        app = FastDash(callback_fn=pick)
+        messages = [str(w.message) for w in caught]
+
+    assert any("nonexistent_param" in m for m in messages)
+    assert app.app.layout is not None
+
+
+# --- resolver-return-type semantics ---
+# We test the pure helper _apply_dependency_resolver since Dash's registered
+# callback is wrapped in a request-context decorator that we can't invoke
+# from a unit test.
+
+
+def test_resolver_list_sets_data_and_clears_value():
+    data, value = FastDash._apply_dependency_resolver(lambda v: ["a", "b", "c"], "USA")
+    assert data == ["a", "b", "c"]
+    assert value is None
+
+
+def test_resolver_dict_sets_data_and_value():
+    data, value = FastDash._apply_dependency_resolver(
+        lambda v: {"data": ["x", "y"], "value": "x"}, "USA"
+    )
+    assert data == ["x", "y"]
+    assert value == "x"
+
+
+def test_resolver_dict_partial_only_sets_provided_keys():
+    data, value = FastDash._apply_dependency_resolver(
+        lambda v: {"value": "only-value"}, "USA"
+    )
+    assert data is dash.no_update
+    assert value == "only-value"
+
+
+def test_resolver_scalar_sets_value_only():
+    data, value = FastDash._apply_dependency_resolver(
+        lambda v: f"Capital of {v}", "USA"
+    )
+    assert data is dash.no_update
+    assert value == "Capital of USA"
+
+
+def test_resolver_exception_is_swallowed():
+    def bad(v):
+        raise RuntimeError("kaboom")
+    data, value = FastDash._apply_dependency_resolver(bad, "USA")
+    assert data is dash.no_update
+    assert value is dash.no_update
+
+
+def test_resolver_none_parent_returns_no_update():
+    data, value = FastDash._apply_dependency_resolver(lambda v: [v], None)
+    assert data is dash.no_update
+    assert value is dash.no_update
+
+
+def test_resolver_receives_parent_value():
+    """The resolver should be called with the parent's current value."""
+    received = []
+
+    def spy(v):
+        received.append(v)
+        return [v]
+
+    FastDash._apply_dependency_resolver(spy, "India")
+    assert received == ["India"]
+
+
+def test_nested_depends_on_chain_builds():
+    """A → B → C: three-level chain should still build a working app."""
+    def pick(
+        continent: str = ["Asia", "Americas"],
+        country: str = depends_on("continent", lambda v: ["India"] if v == "Asia" else ["USA"]),
+        state: str = depends_on("country", lambda v: ["Karnataka"] if v == "India" else ["California"]),
+    ) -> str:
+        return f"{state}, {country}, {continent}"
+
+    app = FastDash(callback_fn=pick)
+    assert app.app.layout is not None
+    # Two dependency callbacks registered (one each for country and state)
+    dep_ids = {c.id for c in app.inputs_with_ids if hasattr(c, "_depends_on_parent")}
+    assert dep_ids == {"country", "state"}

--- a/tests/test_friendly_errors.py
+++ b/tests/test_friendly_errors.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""Tests for ``_friendly_error_message`` — the error string mapper.
+
+When a user's callback raises, Fast Dash maps the raw Python exception
+text to a friendlier message shown in the notification component.
+This test exercises each branch end to end so that adding a new
+error category doesn't silently break the existing ones.
+"""
+from fast_dash.utils import _friendly_error_message
+
+
+def test_none_return_unpack():
+    msg = _friendly_error_message(
+        "'NoneType' object is not subscriptable"
+    )
+    assert "returned None" in msg
+
+
+def test_too_many_values():
+    msg = _friendly_error_message("too many values to unpack (expected 2)")
+    assert "different number of values" in msg
+
+
+def test_argument_mismatch():
+    msg = _friendly_error_message(
+        "my_func() takes 2 positional arguments but 3 were given"
+    )
+    assert "argument mismatch" in msg.lower()
+
+
+def test_typeerror_unsupported_operand():
+    msg = _friendly_error_message(
+        "TypeError: unsupported operand type(s) for +: 'int' and 'str'"
+    )
+    assert "Type mismatch" in msg
+
+
+def test_keyerror():
+    msg = _friendly_error_message("KeyError: 'missing_key'")
+    assert "dictionary key" in msg.lower()
+
+
+def test_value_conversion_error():
+    msg = _friendly_error_message("ValueError: could not convert string to float: 'abc'")
+    assert "couldn't be converted" in msg.lower()
+
+
+def test_division_by_zero():
+    msg = _friendly_error_message("ZeroDivisionError: division by zero")
+    assert "Division by zero" in msg
+
+
+def test_index_error():
+    msg = _friendly_error_message("IndexError: list index out of range")
+    assert "out of range" in msg.lower()
+
+
+def test_json_serialization():
+    msg = _friendly_error_message("Object of type set is not JSON serializable")
+    assert "standard Python types" in msg
+
+
+def test_timeout():
+    msg = _friendly_error_message("TimeoutError: The read operation timed out")
+    assert "timed out" in msg.lower()
+
+
+def test_attribute_error():
+    msg = _friendly_error_message("AttributeError: 'NoneType' object has no attribute 'x'")
+    assert "missing an expected attribute" in msg
+
+
+def test_file_not_found():
+    msg = _friendly_error_message("FileNotFoundError: [Errno 2] No such file or directory: 'foo.csv'")
+    assert "file could not be found" in msg
+
+
+def test_permission_denied():
+    msg = _friendly_error_message("PermissionError: [Errno 13] Permission denied: '/etc/secret'")
+    assert "Permission denied" in msg
+
+
+def test_no_module():
+    msg = _friendly_error_message("ModuleNotFoundError: No module named 'pandas'")
+    assert "Missing dependency" in msg
+    assert "pandas" in msg
+
+
+def test_connection_refused():
+    msg = _friendly_error_message("ConnectionRefusedError: [Errno 61] Connection refused")
+    assert "network connection failed" in msg.lower()
+
+
+def test_memory_error():
+    msg = _friendly_error_message("MemoryError")
+    assert "out of memory" in msg.lower()
+
+
+def test_chat_passthrough():
+    """Chat-component formatting errors are already friendly; pass through verbatim."""
+    msg = _friendly_error_message("Chat component requires a dict with 'query' and 'response'.")
+    assert msg == "Chat component requires a dict with 'query' and 'response'."
+
+
+def test_unknown_error_capitalized_fallback():
+    msg = _friendly_error_message("some random new error")
+    assert msg == "Some random new error"
+
+
+def test_empty_error_fallback():
+    msg = _friendly_error_message("")
+    assert "unexpected error" in msg.lower()

--- a/tests/test_multi_function.py
+++ b/tests/test_multi_function.py
@@ -143,3 +143,112 @@ def test_multi_function_three_functions():
     assert app.func_data[0]["prefix"] == "func0_"
     assert app.func_data[1]["prefix"] == "func1_"
     assert app.func_data[2]["prefix"] == "func2_"
+
+
+# --- dmc-based layout (post-migration) ---
+
+
+class TestMultiFunctionDmcLayout:
+    """Multi-function mode now reuses AppLayout (dmc/AppShell) instead of dbc."""
+
+    def test_layout_uses_mantine_provider_at_root(self):
+        def a(x: str) -> str:
+            return x
+
+        def b(y: int = 1) -> int:
+            return y
+
+        app = FastDash([a, b])
+        # AppLayout wraps everything in a MantineProvider
+        assert "MantineProvider" in type(app.app.layout).__name__
+
+    def test_layout_contains_appshell(self):
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b])
+        layout_str = str(app.app.layout)
+        assert "appshell" in layout_str
+        # Header / navbar IDs come from AppLayout
+        assert "header1162572" in layout_str
+        assert "navbar3260780" in layout_str
+
+    def test_layout_contains_per_tab_panels_with_prefixes(self):
+        def alpha(x: str) -> str: return x
+        def beta(y: int = 1) -> int: return y
+
+        app = FastDash([alpha, beta])
+        layout_str = str(app.app.layout)
+        # Per-tab input + output panels exist for each function
+        assert "func0_input-panel" in layout_str
+        assert "func1_input-panel" in layout_str
+        assert "func0_output-panel" in layout_str
+        assert "func1_output-panel" in layout_str
+
+    def test_layout_uses_dmc_tabs_strip(self):
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b])
+        layout_str = str(app.app.layout)
+        assert "multi-function-tabs" in layout_str
+
+    def test_per_function_loading_overlay_ids_preserved(self):
+        """The per-function callbacks key off these IDs — they must stay."""
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b])
+        layout_str = str(app.app.layout)
+        assert "func0_loading-overlay" in layout_str
+        assert "func1_loading-overlay" in layout_str
+
+    def test_per_function_submit_and_reset_buttons_preserved(self):
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b])
+        layout_str = str(app.app.layout)
+        # The buttons inside _make_input_groups / _make_output_groups
+        assert "func0_submit_inputs" in layout_str
+        assert "func1_submit_inputs" in layout_str
+        assert "func0_reset_inputs" in layout_str
+        assert "func1_reset_inputs" in layout_str
+
+    def test_no_dbc_navbar_or_tabs_remain(self):
+        """Old dbc.NavbarSimple / dbc.Tabs / dbc.Modal should be gone."""
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b])
+        layout_str = str(app.app.layout)
+        # dbc.NavbarSimple → dmc header. dbc.Modal → dmc.Modal.
+        assert "NavbarSimple" not in layout_str
+
+    def test_about_modal_uses_dmc_modal(self):
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b], about=True)
+        layout_str = str(app.app.layout)
+        assert "about-modal" in layout_str
+
+    def test_minimal_mode_strips_chrome(self):
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b], minimal=True)
+        layout_str = str(app.app.layout)
+        # Per-tab panels still exist; chrome bits are gone
+        assert "func0_input-panel" in layout_str
+        assert "func1_input-panel" in layout_str
+
+    def test_callback_count_includes_tab_switcher(self):
+        """Tab switcher + N per-function callbacks + chrome callbacks."""
+        def a(x: str) -> str: return x
+        def b(y: int = 1) -> int: return y
+
+        app = FastDash([a, b])
+        # At minimum: 1 tab switcher + 2 per-fn process + 2 per-fn loading
+        # + 2 per-fn ack + 1 dark-mode + 1 sidebar + 1 about modal = 10
+        assert len(app.app.callback_map) >= 5

--- a/tests/test_new_components.py
+++ b/tests/test_new_components.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+"""Tests for new Fast Dash components exported in v0.2.16."""
+import pytest
+
+from fast_dash import (
+    FastDash,
+    MultiSelect,
+    DateRange,
+    Switch,
+    PasswordInput,
+    Markdown,
+)
+
+
+# --- existence & shape ---
+
+
+def test_multiselect_shape():
+    assert MultiSelect.component_property == "value"
+    assert MultiSelect.tag == "Text"
+    assert MultiSelect.component.__class__.__name__ == "MultiSelect"
+
+
+def test_daterange_shape():
+    assert DateRange.component_property == "value"
+    assert DateRange.tag == "Text"
+    assert DateRange.component.__class__.__name__ == "DatePickerInput"
+
+
+def test_switch_shape():
+    # Switch binds to `checked` not `value`, because dmc.Switch exposes checked
+    assert Switch.component_property == "checked"
+    assert Switch.tag == "Bool"
+    assert Switch.component.__class__.__name__ == "Switch"
+
+
+def test_passwordinput_shape():
+    assert PasswordInput.component_property == "value"
+    assert PasswordInput.tag == "Text"
+    assert PasswordInput.component.__class__.__name__ == "PasswordInput"
+
+
+def test_markdown_shape():
+    # Markdown outputs html children, not a form `value`
+    assert Markdown.component_property == "children"
+    assert Markdown.tag == "Text"
+    assert Markdown.component.__class__.__name__ == "Markdown"
+
+
+# --- integration: building a FastDash app that uses each ---
+
+
+def _build(inputs, outputs):
+    def fn(x):
+        return x
+    return FastDash(callback_fn=fn, inputs=inputs, outputs=outputs)
+
+
+def test_multiselect_as_input_builds_app():
+    app = _build(MultiSelect, Markdown)
+    assert app.app.layout is not None
+
+
+def test_daterange_as_input_builds_app():
+    app = _build(DateRange, Markdown)
+    assert app.app.layout is not None
+
+
+def test_switch_as_input_builds_app():
+    app = _build(Switch, Markdown)
+    assert app.app.layout is not None
+
+
+def test_passwordinput_as_input_builds_app():
+    app = _build(PasswordInput, Markdown)
+    assert app.app.layout is not None
+
+
+def test_markdown_as_output_builds_app():
+    app = _build(PasswordInput, Markdown)
+    # Component exists on output side
+    out_comp = app.outputs_with_ids[0]
+    assert out_comp.component.__class__.__name__ == "Markdown"

--- a/tests/test_plotly_string_annotation.py
+++ b/tests/test_plotly_string_annotation.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""Unit tests for string-form type annotations in output inference.
+
+Ensures that returning a function with a string annotation like
+``"plotly.graph_objects.Figure"`` still produces the right FastComponent,
+rather than falling through to the generic text renderer.
+"""
+from fast_dash.Components import _get_output_components
+
+
+def test_plotly_graph_objects_figure_string():
+    comp = _get_output_components("plotly.graph_objects.Figure")
+    assert comp.tag == "Graph"
+    assert comp.component_property == "figure"
+
+
+def test_plotly_graph_objs_figure_string():
+    comp = _get_output_components("plotly.graph_objs.Figure")
+    assert comp.tag == "Graph"
+    assert comp.component_property == "figure"
+
+
+def test_go_figure_string():
+    comp = _get_output_components("go.Figure")
+    assert comp.tag == "Graph"
+    assert comp.component_property == "figure"
+
+
+def test_bare_figure_string():
+    comp = _get_output_components("Figure")
+    assert comp.tag == "Graph"
+    assert comp.component_property == "figure"
+
+
+def test_dataframe_string_annotations_resolve_to_table():
+    import pandas as pd
+    for s in ("pd.DataFrame", "DataFrame", "pandas.DataFrame"):
+        comp = _get_output_components(s)
+        # These fall into the normal issubclass(pd.DataFrame) branch → Table
+        # The Table FastComponent wraps a DataTable
+        assert "DataTable" in comp.component.__class__.__name__, f"got {comp.component.__class__} for {s}"
+
+
+def test_image_string_annotations_resolve_to_image():
+    import PIL.Image
+    for s in ("PIL.Image.Image", "Image"):
+        comp = _get_output_components(s)
+        # Falls into issubclass(PIL.Image.Image) branch → Image component
+        assert comp.component.__class__.__name__ == "Img", f"got {comp.component.__class__} for {s}"
+
+
+def test_unknown_string_annotation_falls_back_to_text():
+    """Strings we don't recognize should still produce a valid output component."""
+    comp = _get_output_components("SomeRandomType")
+    # Falls through the string-resolution block; ends up as H1 (text fallback)
+    assert comp.component.__class__.__name__ == "H1"

--- a/tests/test_run_button.py
+++ b/tests/test_run_button.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Test that the primary submit button is labeled "Run", not "Submit"."""
+import re
+
+from fast_dash import FastDash, Text
+from fast_dash.utils import _make_input_groups, _assign_ids_to_inputs
+
+
+def test_run_label_in_input_groups():
+    """_make_input_groups should emit a button labeled 'Run' at the end."""
+    def f(x: str) -> str:
+        return x
+
+    inputs_with_ids = _assign_ids_to_inputs([Text], f)
+    groups = _make_input_groups(inputs_with_ids, update_live=False)
+    rendered = str(groups)
+    assert "'Run'" in rendered or '"Run"' in rendered
+    # And the old label is gone
+    assert "'Submit'" not in rendered and '"Submit"' not in rendered
+
+
+def test_show_submit_false_omits_button():
+    """With show_submit=False (used by steps mode), no submit button should render."""
+    def f(x: str) -> str:
+        return x
+
+    inputs_with_ids = _assign_ids_to_inputs([Text], f)
+    groups = _make_input_groups(inputs_with_ids, update_live=False, show_submit=False)
+    rendered = str(groups)
+    # No "Run" button, no submit_inputs id
+    assert "submit_inputs" not in rendered
+    assert "'Run'" not in rendered and '"Run"' not in rendered
+
+
+def test_show_submit_default_is_true():
+    """The default must render the Run button (preserves existing single-function behavior)."""
+    def f(x: str) -> str:
+        return x
+
+    inputs_with_ids = _assign_ids_to_inputs([Text], f)
+    groups = _make_input_groups(inputs_with_ids, update_live=False)  # no show_submit kwarg
+    rendered = str(groups)
+    assert "submit_inputs" in rendered
+
+
+def test_app_layout_contains_run_button():
+    """End-to-end: a FastDash app's layout should contain the 'Run' button."""
+    def f(x: str) -> str:
+        return x
+
+    app = FastDash(callback_fn=f, inputs=Text, outputs=Text)
+    layout_str = str(app.app.layout)
+    assert "'Run'" in layout_str or '"Run"' in layout_str
+    assert '"Submit"' not in layout_str and "'Submit'" not in layout_str

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -143,6 +143,18 @@ class TestStepsAppBuild:
         assert app.is_steps is True
         assert app.is_multi is False
 
+    def test_callback_fn_optional_when_steps_provided(self):
+        """Users should be able to write FastDash(steps=[...]) without callback_fn."""
+        app = FastDash(steps=[_load_data, _double])
+        assert app.is_steps is True
+        assert app.app.layout is not None
+
+    def test_no_callback_fn_and_no_steps_raises(self):
+        """Construction with neither callback_fn nor steps must fail loudly."""
+        import pytest
+        with pytest.raises(TypeError, match="callback_fn|steps"):
+            FastDash()
+
     def test_layout_contains_step_containers_and_buttons(self):
         app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
         layout_str = str(app.app.layout)

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python
+"""Tests for the multi-step pipeline feature.
+
+Pipelines are declared via ``FastDash(steps=[fn_a, fn_b, ...])``. Each step
+function gets its own panel in a stepper UI; downstream steps can pull
+upstream outputs via ``from_step`` defaults. These tests exercise the
+construction-time behavior (signature splitting, layout assembly) and the
+runtime helpers without needing a browser.
+"""
+import inspect
+
+from fast_dash import FastDash, from_step
+import pandas as pd
+
+
+# --- helper: build a small linear pipeline ---
+
+
+def _load_data(rows: int = 10) -> pd.DataFrame:
+    """Generate sample rows."""
+    return pd.DataFrame({"x": list(range(rows)), "y": [i * 2 for i in range(rows)]})
+
+
+def _double(data=from_step(_load_data)) -> pd.DataFrame:
+    """Double every value in the upstream DataFrame."""
+    return data * 2
+
+
+def _summarise(data=from_step(_double), prefix: str = "Result:") -> str:
+    """Return a one-line summary string."""
+    return f"{prefix} {len(data)} rows, sum={data.values.sum()}"
+
+
+# --- _make_user_params_fn ---
+
+
+class TestMakeUserParamsFn:
+    def test_signature_only_includes_listed_params(self):
+        def fn(a: int = 1, b: str = "x", c: float = 0.5): pass
+        params = list(inspect.signature(fn).parameters.items())
+        # Pretend `b` is wired via from_step and shouldn't reach the UI
+        user_params = [p for p in params if p[0] != "b"]
+        synth = FastDash._make_user_params_fn(user_params)
+        assert list(inspect.signature(synth).parameters) == ["a", "c"]
+
+    def test_annotations_are_preserved(self):
+        def fn(a: int, b: str = "x"): pass
+        params = list(inspect.signature(fn).parameters.items())
+        synth = FastDash._make_user_params_fn(params)
+        assert synth.__annotations__ == {"a": int, "b": str}
+
+    def test_defaults_are_preserved(self):
+        def fn(a: int = 42, b: str = "hi"): pass
+        params = list(inspect.signature(fn).parameters.items())
+        synth = FastDash._make_user_params_fn(params)
+        sig = inspect.signature(synth)
+        assert sig.parameters["a"].default == 42
+        assert sig.parameters["b"].default == "hi"
+
+    def test_empty_user_params_produces_empty_signature(self):
+        synth = FastDash._make_user_params_fn([])
+        assert list(inspect.signature(synth).parameters) == []
+
+
+# --- _init_steps: construction & metadata ---
+
+
+class TestInitSteps:
+    def test_step_count_matches_input(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        assert len(app.step_data) == 2
+
+    def test_step_prefixes_are_unique(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double, _summarise])
+        prefixes = [sd["prefix"] for sd in app.step_data]
+        assert prefixes == ["step0_", "step1_", "step2_"]
+        assert len(set(prefixes)) == len(prefixes)
+
+    def test_fn_to_idx_mapping(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double, _summarise])
+        assert app.fn_to_idx == {_load_data: 0, _double: 1, _summarise: 2}
+
+    def test_from_step_params_separated_from_user_params(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double, _summarise])
+        # Step 0: only user params, no from_step
+        assert app.step_data[0]["from_step_params"] == {}
+        assert [p[0] for p in app.step_data[0]["user_params"]] == ["rows"]
+
+        # Step 1: only from_step, no user params
+        assert "data" in app.step_data[1]["from_step_params"]
+        assert app.step_data[1]["user_params"] == []
+
+        # Step 2: mix
+        assert "data" in app.step_data[2]["from_step_params"]
+        assert [p[0] for p in app.step_data[2]["user_params"]] == ["prefix"]
+
+    def test_steps_with_no_user_inputs_have_empty_input_groups(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        # _double has no user params (only from_step)
+        assert app.step_data[1]["inputs_with_ids"] == []
+
+    def test_input_ids_are_prefixed_per_step(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _summarise])
+        # Step 2 (_summarise) has user param `prefix`
+        prefix_ids = [c.id for c in app.step_data[1]["inputs_with_ids"]]
+        assert any("step1_" in i for i in prefix_ids)
+
+    def test_step_titles_derived_from_function_names(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double, _summarise])
+        titles = [sd["title"].strip() for sd in app.step_data]
+        # Leading underscores in the helper names produce a leading space; strip it.
+        assert titles == ["Load Data", "Double", "Summarise"]
+
+    def test_descriptions_pulled_from_docstring(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        # _load_data's docstring is "Generate sample rows."
+        assert "Generate sample rows" in app.step_data[0]["description"]
+
+
+# --- App-level integration ---
+
+
+class TestStepsAppBuild:
+    def test_app_builds_with_two_step_pipeline(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        assert app.app.layout is not None
+
+    def test_app_builds_with_three_step_pipeline(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double, _summarise])
+        assert app.app.layout is not None
+
+    def test_app_builds_with_single_step(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data])
+        assert app.app.layout is not None
+        assert len(app.step_data) == 1
+
+    def test_steps_mode_overrides_multi_function_mode(self):
+        """If both `steps=` and a list `callback_fn=` are provided, steps wins."""
+        app = FastDash(
+            callback_fn=[_load_data, _double],   # would normally be multi-function
+            steps=[_load_data, _double],
+        )
+        assert app.is_steps is True
+        assert app.is_multi is False
+
+    def test_layout_contains_step_containers_and_buttons(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        layout_str = str(app.app.layout)
+        assert "step-inputs-0" in layout_str
+        assert "step-inputs-1" in layout_str
+        assert "step-outputs-0" in layout_str
+        assert "step-outputs-1" in layout_str
+        assert "step-run-btn" in layout_str
+        assert "step-back-btn" in layout_str
+        assert "step-next-btn" in layout_str
+        assert "pipeline-stepper" in layout_str
+
+    def test_layout_contains_session_stores(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        layout_str = str(app.app.layout)
+        assert "step-session-id" in layout_str
+        assert "step-current-idx" in layout_str
+        assert "step-completed-set" in layout_str
+
+    def test_steps_app_registers_callbacks(self):
+        """run, next, back, visibility, session-init = at least 5 callbacks."""
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        assert len(app.app.callback_map) >= 5
+
+
+# --- Backward compatibility ---
+
+
+class TestStepsDoesNotBreakOtherModes:
+    def test_single_function_app_still_works_when_steps_kwarg_omitted(self):
+        def fn(x: str) -> str:
+            return x.upper()
+        app = FastDash(callback_fn=fn)
+        assert app.is_steps is False
+        assert app.app.layout is not None
+
+    def test_multi_function_app_still_works_when_steps_kwarg_omitted(self):
+        def a(x: str) -> str: return x
+        def b(x: int) -> int: return x
+        app = FastDash(callback_fn=[a, b])
+        assert app.is_steps is False
+        assert app.is_multi is True
+        assert app.app.layout is not None
+
+
+# --- from_step behavior ---
+
+
+class TestFromStep:
+    def test_from_step_records_source_function(self):
+        fs = from_step(_load_data)
+        assert fs.source_fn is _load_data
+        assert fs.transform is None
+
+    def test_from_step_with_transform(self):
+        fs = from_step(_load_data, transform=lambda df: list(df.columns))
+        assert fs.source_fn is _load_data
+        assert callable(fs.transform)
+
+    def test_from_step_consumed_by_init_steps(self):
+        """A from_step in a step's signature should be picked up as a from_step_param,
+        not as a user-facing input."""
+        def consumer(data=from_step(_load_data)) -> str:
+            return f"got {len(data)} rows"
+
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, consumer])
+        assert "data" in app.step_data[1]["from_step_params"]
+        # No UI input was created for `data`
+        assert all(
+            "data" not in c.id
+            for c in app.step_data[1]["inputs_with_ids"]
+        )
+
+
+# --- _step_cache lifecycle (a process-level dict) ---
+
+
+class TestStepCache:
+    def setup_method(self, method):
+        # Don't pollute across tests
+        FastDash._step_cache.clear()
+
+    def teardown_method(self, method):
+        FastDash._step_cache.clear()
+
+    def test_cache_is_class_level_dict(self):
+        assert isinstance(FastDash._step_cache, dict)
+
+    def test_cache_can_store_and_retrieve_values(self):
+        FastDash._step_cache["session-A"] = {0: "step-0-result"}
+        assert FastDash._step_cache["session-A"][0] == "step-0-result"
+
+    def test_independent_sessions_dont_collide(self):
+        FastDash._step_cache["session-A"] = {0: "A-result"}
+        FastDash._step_cache["session-B"] = {0: "B-result"}
+        assert FastDash._step_cache["session-A"][0] == "A-result"
+        assert FastDash._step_cache["session-B"][0] == "B-result"
+
+
+# --- Output labels for steps ---
+
+
+class TestStepOutputLabels:
+    def test_each_step_gets_one_output_with_a_label(self):
+        app = FastDash(callback_fn=_load_data, steps=[_load_data, _double])
+        for sd in app.step_data:
+            assert len(sd["outputs_with_ids"]) == 1
+            # Label should be derived from function name
+            assert sd["outputs_with_ids"][0].label_ is not None


### PR DESCRIPTION
## Summary

v0.2.16 ports the non-MCP, non-branching additions from `feature/mcp-support` with thorough test coverage.

### New features

- **Multi-step pipelines** — `FastDash(steps=[fn_a, fn_b, fn_c])` turns a sequence of functions into a wizard with a stepper UI. Outputs of upstream steps thread into downstream step parameters via the new `from_step` default. Linear pipelines only — branching is intentionally out of scope.
- **Reactive inputs** — `depends_on(parent, resolver)` wires a dependent input's options/value to a parent input's value. Resolver semantics: `list` → set options + clear value; `dict` → set the keys present; scalar → set the value; raised exception or `None` parent → no update.
- **5 new components** — `MultiSelect`, `DateRange`, `Switch`, `PasswordInput`, `Markdown`. All exported from the package root.
- **Plotly string annotation fix** — returning a function annotated with `"plotly.graph_objects.Figure"` (string form) now resolves to the `Graph` component instead of falling through to text.

### Polish

- **"Run" button rename** — primary submit button now labeled "Run". A new `show_submit=False` parameter on `_make_input_groups` lets steps mode suppress it.
- **10 friendlier error messages** — `KeyError`, `ZeroDivisionError`, `IndexError`, JSON serialization, timeout, permission, connection, memory, argument mismatch, unsupported operand. Users seeing tracebacks in the notification toast now get actionable phrasing.
- **API ergonomics** — `callback_fn` is optional when `steps=` is provided; passing neither raises a clear `TypeError`.

### Documentation

- README gains a "Built-in components" reference table, a `depends_on` cascading-dropdown example, and a multi-step pipeline example. The output-type table now acknowledges the auto-detected plotly forms.
- `docs/User guide/patterns.md` gains dedicated sections for `depends_on` (with full resolver-return-type semantics) and multi-step pipelines (with navigation, state lifecycle, and known limits).

### Explicitly out of scope

- MCP integration — stays on `feature/mcp-support`.
- Branching pipelines — `FastDash` doesn't accept a `branches=` kwarg in this release.

## Test plan

- [x] **84 new tests** covering: plotly string annotations (8), new components (10), Run button & `show_submit` (4), `depends_on` class + inference + callback registration + resolver semantics (14), friendly error messages (19), `from_step` + `_init_steps` + step layout assembly + `_step_cache` lifecycle + backward compatibility (29). 153 tests total, up from 69 on `dev`.
- [x] Local pytest: 153/153.
- [x] Local tox py313: 153/153.
- [x] CI matrix (4 Python × 2 OS + publish_dev_build): 9/9 pass.
- [x] README pipeline example smoke-tested end-to-end.
- [x] README `depends_on` example smoke-tested end-to-end.

## Commits

1. Add new components, depends_on/from_step helpers, and polish
2. Wire depends_on runtime: register reactive callbacks between inputs
3. Expand friendly error messages and register new dmc components
4. Document new components and depends_on; bump to 0.2.16
5. Trigger dev workflow on PRs targeting dev
6. Add steps pipeline mode for linear multi-step apps
7. Document steps; make callback_fn optional when steps= is provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)