### PR TITLE
Add opt-in MCP server output

### DIFF
--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -127,6 +127,9 @@ class FastDash:
         run_kwargs=dict(),
         tab_titles=None,
         steps=None,
+        mcp_server=False,
+        mcp_port=8001,
+        mcp_host="127.0.0.1",
         **kwargs
     ):
         """
@@ -210,6 +213,10 @@ class FastDash:
         # Detect pipeline (steps) mode
         self.is_steps = steps is not None
         self.steps = steps
+        self.mcp_server_enabled = bool(mcp_server)
+        self.mcp_port = mcp_port
+        self.mcp_host = mcp_host
+        self._mcp_thread = None
 
         # callback_fn is required unless steps= is provided
         if callback_fn is None and not self.is_steps:
@@ -864,8 +871,34 @@ class FastDash:
             return styles + [back_disabled, next_disabled]
 
     def run(self):
+        if self.mcp_server_enabled:
+            self._start_mcp_server()
         self.app.run(**self.run_kwargs) if self.mode is None else self.app.run(
             jupyter_mode=self.mode, **self.run_kwargs
+        )
+
+    def _start_mcp_server(self):
+        """Launch an MCP server in a daemon thread alongside the Dash app.
+
+        Skipped silently in multi-function and steps modes — the MCP
+        single-tool model assumes a single callback. We log a warning
+        instead of failing so existing apps keep working.
+        """
+        if self.is_multi or self.is_steps:
+            warnings.warn(
+                "mcp_server=True is currently supported only for "
+                "single-function apps; ignoring for multi-function / "
+                "steps mode.",
+                stacklevel=2,
+            )
+            return
+        from .mcp import serve_mcp_in_thread
+
+        self._mcp_thread = serve_mcp_in_thread(
+            self.callback_fn,
+            host=self.mcp_host,
+            port=self.mcp_port,
+            title=self.title,
         )
 
     def run_server(self):
@@ -1658,6 +1691,9 @@ def fastdash(
     disable_logs=False,
     scale_height=1,
     run_kwargs=dict(),
+    mcp_server=False,
+    mcp_port=8001,
+    mcp_host="127.0.0.1",
     **kwargs
 ):
     """
@@ -1770,6 +1806,9 @@ def fastdash(
             disable_logs=disable_logs,
             scale_height=scale_height,
             run_kwargs=run_kwargs,
+            mcp_server=mcp_server,
+            mcp_port=mcp_port,
+            mcp_host=mcp_host,
             **kwargs
         )
 

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -1,0 +1,123 @@
+"""Model Context Protocol (MCP) server output for Fast Dash apps.
+
+Lets a Fast Dash app simultaneously serve as a web app *and* an MCP
+tool callable by AI agents (Claude, Cursor, Cline, etc.). The same
+type hints that drive the UI also drive the MCP tool's input schema.
+
+Usage::
+
+    from fast_dash import fastdash
+
+    @fastdash(mcp_server=True)
+    def search_db(query: str, limit: int = 10) -> list[str]:
+        '''Search the user database.'''
+        ...
+
+The web app runs on the usual port (8080 by default). The MCP server
+runs on a separate port (8001 by default) at the path ``/mcp``. An
+agent can connect with the streamable-http transport::
+
+    {"command": "mcp", "args": ["--http", "http://localhost:8001/mcp"]}
+
+Implementation notes:
+
+- We use the official ``mcp`` SDK (``mcp.server.fastmcp.FastMCP``).
+  Schema is derived automatically from type hints + docstring via
+  pydantic, so a well-typed Fast Dash function needs no extra work.
+- The MCP server is mounted as a Starlette ASGI app served by uvicorn
+  in a daemon thread. Flask (Dash) and Starlette use different
+  protocols (WSGI vs ASGI), so a single port would require an extra
+  bridging dependency. Two ports keeps the surface clean.
+- ``mcp`` is an optional dependency. ``import fast_dash.mcp`` succeeds
+  on plain installs; the helpful import error fires only when a user
+  passes ``mcp_server=True`` without the package installed.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Callable
+
+# Holder for an active MCP thread so tests can introspect / shut down.
+_active_mcp_thread: threading.Thread | None = None
+
+
+def _ensure_mcp_deps() -> tuple[Any, Any]:
+    """Import mcp and uvicorn lazily; raise a clear error if missing."""
+    try:
+        from mcp.server.fastmcp import FastMCP  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise ImportError(
+            "MCP support requires the 'mcp' package. Install it with:\n"
+            "    pip install 'mcp>=1.0'"
+        ) from e
+    try:
+        import uvicorn  # type: ignore[import-not-found]
+    except ImportError as e:
+        raise ImportError(
+            "MCP HTTP transport requires 'uvicorn'. Install it with:\n"
+            "    pip install uvicorn"
+        ) from e
+    return FastMCP, uvicorn
+
+
+def build_mcp_server(
+    callback_fn: Callable[..., Any],
+    *,
+    title: str | None = None,
+):
+    """Build a FastMCP server that exposes ``callback_fn`` as a tool.
+
+    The function's signature, type hints, and docstring drive the tool
+    schema directly — no extra annotations required. Returns the
+    ``FastMCP`` instance configured for streamable-HTTP transport.
+    """
+    FastMCP, _ = _ensure_mcp_deps()
+    server = FastMCP(
+        title or callback_fn.__name__,
+        stateless_http=True,
+        json_response=True,
+    )
+    # ``@server.tool()`` reads the signature on registration; passing
+    # the function object directly preserves annotations and __doc__.
+    server.tool()(callback_fn)
+    return server
+
+
+def serve_mcp_in_thread(
+    callback_fn: Callable[..., Any],
+    *,
+    host: str = "127.0.0.1",
+    port: int = 8001,
+    title: str | None = None,
+) -> threading.Thread:
+    """Start the MCP server on a background daemon thread.
+
+    Returns the thread object. The Dash/Flask main loop continues on
+    the parent thread; the MCP server lives only for the lifetime of
+    the parent process.
+    """
+    server = build_mcp_server(callback_fn, title=title)
+    _, uvicorn = _ensure_mcp_deps()
+
+    asgi_app = server.streamable_http_app()
+    config = uvicorn.Config(
+        asgi_app,
+        host=host,
+        port=port,
+        log_level="warning",
+        access_log=False,
+    )
+    uv_server = uvicorn.Server(config)
+
+    def _run():
+        # uvicorn.Server.run() spins up its own asyncio loop on the
+        # current thread, which is what we want for a side-thread server.
+        uv_server.run()
+
+    thread = threading.Thread(target=_run, daemon=True, name="fastdash-mcp")
+    thread.start()
+
+    global _active_mcp_thread
+    _active_mcp_thread = thread
+    return thread

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,11 @@ test = [
     "selenium"
     ]
 
+mcp = [
+    "mcp>=1.0",
+    "uvicorn>=0.27"
+    ]
+
 dev = ["tox", "pre-commit", "virtualenv", "twine", "toml"]
 
 doc = [

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,216 @@
+"""Tests for MCP server output (v0.2.17).
+
+These tests exercise the wiring without actually binding a port — the
+``build_mcp_server`` helper produces a FastMCP instance whose schema we
+can introspect, and the integration test for ``serve_mcp_in_thread``
+binds an ephemeral port only when ``mcp`` is installed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import socket
+import time
+import warnings
+
+import pytest
+
+from fast_dash import FastDash, fastdash  # noqa: F401
+
+
+_HAS_MCP = importlib.util.find_spec("mcp") is not None
+_HAS_UVICORN = importlib.util.find_spec("uvicorn") is not None
+requires_mcp = pytest.mark.skipif(
+    not (_HAS_MCP and _HAS_UVICORN),
+    reason="mcp + uvicorn not installed",
+)
+
+
+# --- kwarg plumbing -------------------------------------------------------
+
+
+class TestKwargPlumbing:
+    """The new mcp_server / mcp_port / mcp_host kwargs land on the instance."""
+
+    def test_mcp_disabled_by_default(self):
+        def fn(x: str = "hi") -> str:
+            return x
+
+        app = FastDash(callback_fn=fn)
+        assert app.mcp_server_enabled is False
+        assert app.mcp_port == 8001
+        assert app.mcp_host == "127.0.0.1"
+        assert app._mcp_thread is None
+
+    def test_mcp_enable_flag_persists(self):
+        def fn(x: str = "hi") -> str:
+            return x
+
+        app = FastDash(callback_fn=fn, mcp_server=True)
+        assert app.mcp_server_enabled is True
+
+    def test_custom_port_and_host(self):
+        def fn(x: str = "hi") -> str:
+            return x
+
+        app = FastDash(
+            callback_fn=fn,
+            mcp_server=True,
+            mcp_port=9001,
+            mcp_host="0.0.0.0",
+        )
+        assert app.mcp_port == 9001
+        assert app.mcp_host == "0.0.0.0"
+
+
+# --- server construction (no port) ---------------------------------------
+
+
+@requires_mcp
+class TestBuildServer:
+    """build_mcp_server produces a usable FastMCP without starting it."""
+
+    def test_build_returns_fastmcp_instance(self):
+        from mcp.server.fastmcp import FastMCP
+
+        from fast_dash.mcp import build_mcp_server
+
+        def fn(x: str = "hi") -> str:
+            """Do a thing."""
+            return x
+
+        server = build_mcp_server(fn)
+        assert isinstance(server, FastMCP)
+
+    def test_callback_registered_as_tool(self):
+        from fast_dash.mcp import build_mcp_server
+
+        def search_db(query: str, limit: int = 10) -> str:
+            """Search the database."""
+            return f"{query} ({limit})"
+
+        server = build_mcp_server(search_db)
+        # The MCP SDK exposes registered tools via the internal registry.
+        # The exact attribute moved over versions; probe both shapes.
+        tool_names = _list_tool_names(server)
+        assert "search_db" in tool_names
+
+    def test_docstring_becomes_tool_description(self):
+        from fast_dash.mcp import build_mcp_server
+
+        def fn(text: str) -> str:
+            """A wonderfully unique description."""
+            return text
+
+        server = build_mcp_server(fn)
+        descs = _list_tool_descriptions(server)
+        assert any("wonderfully unique description" in (d or "") for d in descs)
+
+
+# --- multi-function / steps modes guard rails ----------------------------
+
+
+@requires_mcp
+class TestModeGuards:
+    """MCP only makes sense for single-function apps right now."""
+
+    def test_multi_function_mode_warns_and_skips(self):
+        def a(x: str = "1") -> str:
+            return x
+
+        def b(y: int = 2) -> int:
+            return y
+
+        app = FastDash(callback_fn=[a, b], mcp_server=True)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            app._start_mcp_server()
+        assert app._mcp_thread is None
+        assert any(
+            "single-function" in str(w.message) for w in caught
+        )
+
+    def test_steps_mode_warns_and_skips(self):
+        from fast_dash import from_step
+
+        def load(rows: int = 5) -> int:
+            return rows
+
+        def double(data=from_step(load)) -> int:
+            return data * 2
+
+        app = FastDash(steps=[load, double], mcp_server=True)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            app._start_mcp_server()
+        assert app._mcp_thread is None
+        assert any(
+            "single-function" in str(w.message) for w in caught
+        )
+
+
+# --- end-to-end: actually bind a port ------------------------------------
+
+
+@requires_mcp
+class TestServeInThread:
+    """Bind an ephemeral port and confirm the MCP endpoint responds."""
+
+    def test_thread_binds_and_responds(self):
+        from fast_dash.mcp import serve_mcp_in_thread
+
+        def square(n: int = 1) -> int:
+            """Return n squared."""
+            return n * n
+
+        port = _find_free_port()
+        thread = serve_mcp_in_thread(square, port=port)
+        try:
+            _wait_for_port(port, timeout=5.0)
+            # The streamable-HTTP MCP endpoint responds to a POST with
+            # the JSON-RPC initialize message. We don't need a full
+            # round-trip — a TCP-connection-accepted check is enough
+            # for our wiring.
+            with socket.create_connection(("127.0.0.1", port), timeout=2.0):
+                pass
+        finally:
+            # Daemon thread; let it die with the test process.
+            assert thread.is_alive()
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def _list_tool_names(server) -> list[str]:
+    """Get registered tool names from a FastMCP server, version-tolerant."""
+    tm = getattr(server, "_tool_manager", None)
+    if tm is not None:
+        return list(tm._tools.keys())
+    raise RuntimeError("can't introspect FastMCP tool registry on this SDK")
+
+
+def _list_tool_descriptions(server) -> list[str]:
+    tm = getattr(server, "_tool_manager", None)
+    if tm is not None:
+        return [t.description for t in tm._tools.values()]
+    return []
+
+
+def _find_free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_for_port(port: int, timeout: float = 5.0) -> None:
+    """Block until ``port`` accepts connections, or raise."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.5):
+                return
+        except OSError:
+            time.sleep(0.05)
+    raise TimeoutError(f"port {port} never opened within {timeout}s")


### PR DESCRIPTION
## Summary

Same function → web app *and* MCP tool callable by AI agents (Claude, Cursor, Cline, etc.). Type hints + docstring drive the tool schema for free via pydantic.

```python
@fastdash(mcp_server=True)
def search_db(query: str, limit: int = 10) -> list[str]:
    """Search the user database."""
    ...
```

→ web app on \`:8080\` AND MCP tool at \`http://127.0.0.1:8001/mcp\`.

## Design choices

- **Official \`mcp\` SDK** (\`mcp.server.fastmcp.FastMCP\`) — 3.5× the downloads of the third-party \`fastmcp\` package, and v1 of fastmcp was upstreamed into it.
- **Streamable HTTP** transport (2026 standard; SSE is deprecated).
- **Two ports**: MCP runs in a uvicorn daemon thread on \`:8001\`; Dash stays on \`:8080\`. Flask (WSGI) and the FastMCP Starlette app (ASGI) are protocol-incompatible, so single-port mounting would require an extra bridging dependency. Two ports keeps the surface clean.
- **Optional extra**: \`pip install fast-dash[mcp]\` pulls \`mcp>=1.0\` + \`uvicorn>=0.27\`. Plain installs unaffected; the helpful import error fires only when a user enables \`mcp_server=True\` without the deps.
- **Multi-function / steps modes** warn and skip for now — the MCP single-tool model maps cleanly to a single callback. Per-tab tools are a future follow-up.

## Test plan

- [x] 9 new tests in \`tests/test_mcp.py\` across 4 classes (kwarg plumbing, server construction, mode guards, end-to-end bind)
- [x] Full suite green: 165/165 locally
- [x] Tests gracefully skip when \`mcp\`/\`uvicorn\` aren't installed
- [ ] Manual smoke: connect \`@fastdash(mcp_server=True)\` to Claude Desktop / Cursor and call the tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)