### PR TITLE
ci: persist docs.fastdash.app CNAME on every docs deploy

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -47,3 +47,6 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./site
+          # Write the CNAME on every deploy so GitHub Pages keeps the custom
+          # domain instead of resetting it each publish.
+          cname: docs.fastdash.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./site
+          # Write the CNAME on every deploy so GitHub Pages keeps the custom
+          # domain instead of resetting it each publish.
+          cname: docs.fastdash.app
 
       - name: Build wheels and source tarball
         run: >-


### PR DESCRIPTION
Adds cname: docs.fastdash.app to the peaceiris/actions-gh-pages step in both publish-documentation.yml and release.yml so GitHub Pages keeps the custom domain instead of resetting it after each deploy (no more manual re-entry). Complements the docs/CNAME file added in #93/#94.