### PR TITLE
Promote CNAME-persist CI fix to release

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -47,3 +47,6 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./site
+          # Write the CNAME on every deploy so GitHub Pages keeps the custom
+          # domain instead of resetting it each publish.
+          cname: docs.fastdash.app

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
         with:
           personal_token: ${{ secrets.PERSONAL_TOKEN }}
           publish_dir: ./site
+          # Write the CNAME on every deploy so GitHub Pages keeps the custom
+          # domain instead of resetting it each publish.
+          cname: docs.fastdash.app
 
       - name: Build wheels and source tarball
         run: >-


### PR DESCRIPTION
Brings the cname: docs.fastdash.app deploy fix (PR #95) to release so release.yml writes the CNAME on every docs publish. Docs-only/CI-only.