### PR TITLE
ci: fix retired ubuntu-20.04 runner in docs workflow

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   publish:
     name: Publish documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
The documentation workflow used runs-on: ubuntu-20.04, whose hosted runner GitHub retired, so manual dispatches queued forever. Switched to ubuntu-latest (matches release.yml/dev.yml). Verified: a deploy from this branch ran immediately and published docs.fastdash.app with the CNAME and new AI agents page.