### PR TITLE
Promote docs-runner fix to release

### DIFF
--- a/.github/workflows/publish-documentation.yml
+++ b/.github/workflows/publish-documentation.yml
@@ -18,7 +18,7 @@ jobs:
   # This workflow contains a single job called "build"
   publish:
     name: Publish documentation
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
Brings the publish-documentation.yml runner fix (ubuntu-20.04 -> ubuntu-latest, PR #97) to release so manual docs dispatches from release run instead of hanging in queue. CI/docs infra only.