### PR TITLE
Release prep 0.3.1 (dogfood fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
-# Release 0.3.0
+# Release 0.3.1
+
+## 0.3.1 (2026-06-25)
+
+### Bug fixes
+- **`backend="fastapi"` now works when run as a script.** Previously the ASGI
+  backend never bound (Dash 4.3 infers the uvicorn import string by frame-walking,
+  which fast_dash's extra `run()` frame broke), and Dash's native `/mcp` route
+  500'd on the ASGI backend. fast_dash now serves the ASGI app object directly via
+  uvicorn and installs a small middleware that sets the request context for `/mcp`.
+- **`DynamicDash(..., port=...)`** no longer raises a `TypeError` from `dash.Dash()`;
+  the port is used as `run()`'s default (an explicit `run(port=...)` still wins).
+
+### Added
+- **`describe_app()` MCP tool** — returns the input contract *and* current state
+  for a headless agent: each input's id, type, default, allowed options, and
+  `current_value` (including values set via `set_input` / `set_inputs`, which the
+  native `dash://components` / `get_dash_component` don't surface without a browser).
+
+### Changed
+- The `set_inputs` MCP tool argument is renamed `values` → `inputs` to match
+  `invoke(inputs=...)`.
+- Docs: the per-parameter agent contract lives in `describe_app()`, not the drive
+  tools' raw input schemas.
 
 ## 0.3.0 (2026-06-20)
 

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from fast_dash.Components import (
     Graph,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.0"
+version = "0.3.1"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."


### PR DESCRIPTION
Version bump 0.3.0 -> 0.3.1 + CHANGELOG for the dogfood fixes already merged via #103 (FastAPI backend blocker #99, describe_app read-back/contract #100/#102, set_inputs/DynamicDash-port nits). Version + changelog only. After this: dev -> release, then tag v0.3.1 to publish.