### PR TITLE
Release 0.3.1 - dogfood fixes (FastAPI backend, describe_app)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
-# Release 0.3.0
+# Release 0.3.1
+
+## 0.3.1 (2026-06-25)
+
+### Bug fixes
+- **`backend="fastapi"` now works when run as a script.** Previously the ASGI
+  backend never bound (Dash 4.3 infers the uvicorn import string by frame-walking,
+  which fast_dash's extra `run()` frame broke), and Dash's native `/mcp` route
+  500'd on the ASGI backend. fast_dash now serves the ASGI app object directly via
+  uvicorn and installs a small middleware that sets the request context for `/mcp`.
+- **`DynamicDash(..., port=...)`** no longer raises a `TypeError` from `dash.Dash()`;
+  the port is used as `run()`'s default (an explicit `run(port=...)` still wins).
+
+### Added
+- **`describe_app()` MCP tool** — returns the input contract *and* current state
+  for a headless agent: each input's id, type, default, allowed options, and
+  `current_value` (including values set via `set_input` / `set_inputs`, which the
+  native `dash://components` / `get_dash_component` don't surface without a browser).
+
+### Changed
+- The `set_inputs` MCP tool argument is renamed `values` → `inputs` to match
+  `invoke(inputs=...)`.
+- Docs: the per-parameter agent contract lives in `describe_app()`, not the drive
+  tools' raw input schemas.
 
 ## 0.3.0 (2026-06-20)
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Point an agent at `http://localhost:8080/mcp`:
 {"servers": {"my-app": {"url": "http://localhost:8080/mcp"}}}
 ```
 
-The agent gets **native Dash resources** to introspect the live app — `dash://layout`, `dash://components`, and the `get_dash_component` tool — plus fast_dash **tools** that *drive* it: `set_input` / `set_inputs` / `invoke` / `set_form` / `get_invocation` / `list_component_types`. Agent mutations apply to the live browser within ~500 ms (no reload).
+The agent calls **`describe_app()`** to discover the input contract (each input's id, type, default, options, and current value), then **drives** the app with `set_input` / `set_inputs` / `invoke` / `set_form` / `get_invocation` / `list_component_types`. Dash's native `dash://layout` / `dash://components` / `get_dash_component` expose the static component tree. Agent mutations apply to the live browser within ~500 ms (no reload).
 
 ```python
 # From the agent's side, in one call:

--- a/docs/User guide/ai_agents.md
+++ b/docs/User guide/ai_agents.md
@@ -5,7 +5,9 @@
 Pass `mcp_server=True` and your Fast Dash app serves a web UI **and** a
 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server, so any
 MCP-capable agent — Claude Code, Cursor, Cline, … — can inspect and drive it.
-The same type hints that build the UI also build the agent-facing schemas.
+The same type hints that build the UI describe the inputs an agent sees via the
+[`describe_app`](#discover-the-input-contract) tool (id, type, default, allowed
+options, and current value).
 
 The MCP server is built on [Dash's native MCP support](https://dash.plotly.com)
 (Dash ≥ 4.3, installed automatically) and is mounted on the **same port** as the
@@ -33,18 +35,42 @@ Point any MCP client at the app's `/mcp` endpoint (streamable HTTP):
 
 | Surface | Provided by | Use |
 |---|---|---|
-| `dash://layout`, `dash://components` | Dash (native) | Read the live component tree |
-| `get_dash_component` | Dash (native) | Read a single component's current props |
+| `describe_app()` | Fast Dash | **Start here.** The input contract + current state: each input's id, type, default, options, and current value |
 | `set_input(component_id, value)` | Fast Dash | Set one input |
-| `set_inputs({...})` | Fast Dash | Set several inputs at once |
+| `set_inputs(inputs)` | Fast Dash | Set several inputs at once (`inputs` is a `{id: value}` dict) |
 | `invoke(inputs=None)` | Fast Dash | Run the callback (optionally setting inputs first), in one call |
 | `set_form(specs)` | Fast Dash | Generate a form at runtime (`DynamicDash` only) |
 | `get_invocation(index)` | Fast Dash | Fetch a past run's full kwargs + result |
 | `list_component_types()` | Fast Dash | List the legal component types for `set_form` |
+| `dash://layout`, `dash://components`, `get_dash_component` | Dash (native) | Read the static component tree (ids + Dash widget types) |
 
-`component_id` is the **parameter name** itself (e.g. `"n"`, `"color"`). Read
-`dash://components` (or call `get_dash_component`) to discover the exact ids and
-their current values.
+`component_id` is the **parameter name** itself (e.g. `"n"`, `"color"`).
+
+### Discover the input contract
+
+Call **`describe_app()`** to learn the exact input ids, their Python types,
+defaults, allowed options, and **current values** — and use that to build a valid
+`invoke` call:
+
+```json
+{
+  "title": "Plot Bars",
+  "doc": "Plot a bar chart with n bars in the chosen color.",
+  "inputs": [
+    {"id": "n",     "type": "integer", "default": 6,         "options": null, "current_value": 6},
+    {"id": "color", "type": "string",  "default": "#1c7ed6", "options": null, "current_value": "#1c7ed6"}
+  ]
+}
+```
+
+!!! note
+    The drive tools' (`invoke` / `set_inputs` / `set_input`) raw MCP *input
+    schemas* are generic objects — the per-parameter contract lives in
+    `describe_app()`, not in those tool schemas. The native `dash://components`
+    resource lists ids and Dash *widget* types only, and `get_dash_component`
+    reflects the **browser**, so for a headless agent neither shows values an
+    agent set via `set_input`/`set_inputs` — use `describe_app()` for current
+    values.
 
 ## Drive it from the agent
 

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.0"
+__version__ = "0.3.1"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/dynamic.py
+++ b/fast_dash/dynamic.py
@@ -245,6 +245,11 @@ class DynamicDash:
             _prepare_output(c, i) for i, c in enumerate(self.output_components)
         ]
 
+        # `port` is a run() option, not a Dash() constructor kwarg. Accept it
+        # here (mirroring FastDash) and use it as run()'s default, instead of
+        # leaking it to dash.Dash() where it raises an opaque TypeError.
+        self._port = dash_kwargs.pop("port", None)
+
         self.app = dash.Dash(
             __name__,
             external_stylesheets=dash_kwargs.pop("external_stylesheets", []),
@@ -501,13 +506,16 @@ class DynamicDash:
                     result.append(no_update)
                 return result[:n_out]
 
-    def run(self, debug: bool = False, port: int = 8050, **kwargs):
+    def run(self, debug: bool = False, port: int = None, **kwargs):
         """Convenience wrapper around the Dash dev server.
 
         When ``mcp_server=True`` was passed to the constructor, Dash's native
         MCP server is mounted on this app first (shared port, ``/mcp``) — same
-        one-call contract as :class:`FastDash`.
+        one-call contract as :class:`FastDash`. An explicit ``run(port=...)``
+        wins over a ``DynamicDash(..., port=...)`` constructor value.
         """
+        if port is None:
+            port = self._port if self._port is not None else 8050
         if self.mcp_server_enabled:
             from fast_dash.mcp import enable_mcp
 

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -907,9 +907,33 @@ class FastDash:
     def run(self):
         if self.mcp_server_enabled:
             self._start_mcp_server()
+
+        if self._backend:
+            self._run_asgi()
+            return
+
         self.app.run(**self.run_kwargs) if self.mode is None else self.app.run(
             jupyter_mode=self.mode, **self.run_kwargs
         )
+
+    def _run_asgi(self):
+        """Serve the ASGI (FastAPI/Quart) app object directly via uvicorn.
+
+        Dash 4.3's ASGI ``run()`` infers a uvicorn import string by walking the
+        call stack (``inspect.stack()[2]``), assuming the user called
+        ``app.run()`` directly. fast_dash adds an extra ``run()`` frame, so that
+        heuristic resolves to ``fast_dash/fast_dash.py`` instead of the user's
+        script and uvicorn fails to import the app (issue #99). Serving the app
+        object directly — exactly what Dash's own threaded branch does — sidesteps
+        the import-string heuristic entirely and blocks like a normal dev server.
+        """
+        import uvicorn
+
+        host = self.run_kwargs.get("host", "127.0.0.1")
+        port = self.run_kwargs.get("port", self.port)
+        uvicorn.Server(
+            uvicorn.Config(self.app.server, host=host, port=port, log_level="warning")
+        ).run()
 
     def _start_mcp_server(self):
         """Mount Dash's native MCP server on this app (shared port, ``/mcp``).

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -219,6 +219,28 @@ def _seed_input_mirror(fd) -> None:
         pass
 
 
+def _json_type_name(annotation) -> str:
+    """Best-effort JSON-schema type name for a Python annotation."""
+    return {
+        int: "integer", float: "number", str: "string",
+        bool: "boolean", list: "array", dict: "object",
+    }.get(annotation, "string")
+
+
+def _annotation_options(annotation):
+    """Allowed values for a Literal[...] or Enum annotation, else None."""
+    try:
+        import enum
+        import typing
+        if typing.get_origin(annotation) is typing.Literal:
+            return list(typing.get_args(annotation))
+        if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
+            return [e.value for e in annotation]
+    except Exception:
+        pass
+    return None
+
+
 # --------------------------------------------------------------------------- #
 # Native MCP mount + fast_dash tool registration
 # --------------------------------------------------------------------------- #
@@ -289,11 +311,14 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         return {"ok": True, "id": component_id, "value": _jsonify_for_mcp(value)}
 
     @mcp_enabled(name="set_inputs", expose_docstring=True)
-    def set_inputs(values: dict) -> dict:
-        """Bulk-update multiple input values."""
+    def set_inputs(inputs: dict) -> dict:
+        """Bulk-update multiple input values (keyed by parameter name).
+
+        The argument is named ``inputs`` to match ``invoke(inputs=...)``.
+        """
         ids = {d["id"] for d in _enumerate_inputs(fd)}
         applied, errors = {}, {}
-        for k, v in (values or {}).items():
+        for k, v in (inputs or {}).items():
             if ids and k not in ids:
                 errors[k] = "unknown id"
                 continue
@@ -422,5 +447,129 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         """List the legal ``type`` values for a DynamicDash UI spec."""
         return {"types": _component_types()}
 
-    # Mount the MCP routes on the Dash app (Flask url rules; same port).
+    @mcp_enabled(name="describe_app", expose_docstring=True)
+    def describe_app() -> dict:
+        """Describe the app's inputs: id, type, default, options, and CURRENT value.
+
+        This is the reliable way for a headless agent (no browser) to read the
+        app's input contract *and* its live state before calling ``invoke``:
+        each input reports its parameter ``id``, JSON ``type``, ``default``,
+        any allowed ``options`` (for dropdowns / ``Literal`` / ``Enum``), and
+        its ``current_value`` — including values you set via ``set_input`` /
+        ``set_inputs``. (The native ``dash://components`` resource lists ids and
+        Dash *widget* types only, and ``get_dash_component`` reflects the
+        browser, not the agent's mirror, so neither shows agent-set values
+        headlessly.)
+        """
+        snapshot = dict(state.inputs)
+        descriptors = _enumerate_inputs(fd)
+        try:
+            sig_params = dict(inspect.signature(fd.callback_fn).parameters)
+        except (TypeError, ValueError):
+            sig_params = {}
+        # Resolve string annotations (modules using ``from __future__ import
+        # annotations``) to real types; fall back to the raw annotation.
+        try:
+            import typing
+            hints = typing.get_type_hints(fd.callback_fn)
+        except Exception:
+            hints = {}
+
+        inputs = []
+        if descriptors:
+            for d in descriptors:
+                cid = d["id"]
+                param = _param_name_from_id(cid)
+                p = sig_params.get(param) or sig_params.get(cid)
+                jtype, default, options = "string", None, None
+                if p is not None:
+                    ann = hints.get(param, hints.get(cid, p.annotation))
+                    jtype = _json_type_name(ann)
+                    options = _annotation_options(ann)
+                    if p.default is not inspect.Parameter.empty:
+                        if isinstance(p.default, list) and options is None:
+                            options = list(p.default)
+                        else:
+                            default = p.default
+                cur = snapshot.get(cid, snapshot.get(param))
+                inputs.append({
+                    "id": cid,
+                    "tag": d["tag"],
+                    "type": jtype,
+                    "default": _jsonify_for_mcp(default),
+                    "options": _jsonify_for_mcp(options),
+                    "current_value": _jsonify_for_mcp(cur),
+                })
+        else:
+            # DynamicDash / **kwargs callback: no static inputs — reflect the
+            # current mirror (whatever set_form/set_inputs populated).
+            for k, v in snapshot.items():
+                inputs.append({"id": k, "current_value": _jsonify_for_mcp(v)})
+
+        return {
+            "title": getattr(fd, "title", None) or "",
+            "doc": (getattr(fd.callback_fn, "__doc__", "") or "").strip(),
+            "inputs": inputs,
+        }
+
+    # Mount the MCP routes on the Dash app (same port).
     enable_mcp_server(fd.app, mcp_path)
+
+    # On an ASGI backend, work around an upstream Dash 4.3 bug that breaks the
+    # /mcp route (see _install_asgi_mcp_request_context).
+    if getattr(fd, "_backend", None):
+        _install_asgi_mcp_request_context(fd.app.server, mcp_path)
+
+
+def _install_asgi_mcp_request_context(server, mcp_path: str) -> None:
+    """Make Dash's native ``/mcp`` route work on the FastAPI/Quart backend.
+
+    Dash 4.3's ``DashMiddleware`` only sets the per-request context (and the
+    pre-parsed ``request.state.json_body``) for ``/_dash-*`` routes — it passes
+    every other path straight through "to avoid consuming the body stream". But
+    Dash's own native ``/mcp`` route (added via ``add_url_rule``) is *not* a
+    ``/_dash-`` route, so its sync POST handler raises
+    ``RuntimeError: No active request in context`` (and then ``json_body``
+    missing) on the ASGI backend. Until that's fixed upstream, we add a tiny
+    ASGI middleware that sets the request context + parsed body for the ``/mcp``
+    path so the handler works. No-op if Starlette / the FastAPI backend isn't
+    present (e.g. the default Flask backend).
+    """
+    try:
+        from dash.backends._fastapi import (  # type: ignore[import-not-found]
+            reset_current_request,
+            set_current_request,
+        )
+        from starlette.requests import Request  # type: ignore[import-not-found]
+    except Exception:
+        return
+
+    suffix = "/" + mcp_path.strip("/")
+
+    class _MCPRequestContext:
+        def __init__(self, app):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            if scope.get("type") == "http" and scope.get(
+                "path", ""
+            ).rstrip("/").endswith(suffix):
+                request = Request(scope, receive=receive)
+                try:
+                    ct = request.headers.get("content-type", "")
+                    request.state.json_body = (
+                        await request.json()
+                        if ct.startswith("application/json")
+                        else None
+                    )
+                except Exception:
+                    request.state.json_body = None
+                token = set_current_request(request)
+                try:
+                    await self.app(scope, receive, send)
+                finally:
+                    reset_current_request(token)
+            else:
+                await self.app(scope, receive, send)
+
+    server.add_middleware(_MCPRequestContext)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.0"
+version = "0.3.1"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -271,6 +271,32 @@ def test_dynamicdash_explicit_specs_win_over_placeholder():
     assert app.initial_specs == [{"name": "x", "type": "Text"}]
 
 
+def test_dynamicdash_accepts_port_kwarg():
+    # #100 nit: DynamicDash(..., port=...) used to leak to dash.Dash() and crash.
+    app = DynamicDash(
+        callback_fn=lambda **k: k,
+        initial_specs=[{"name": "x", "type": "Text"}],
+        output_components=[Markdown],
+        port=8123,
+    )
+    assert app._port == 8123
+
+
+def test_dynamicdash_run_port_precedence(monkeypatch):
+    app = DynamicDash(
+        callback_fn=lambda **k: k,
+        initial_specs=[{"name": "x", "type": "Text"}],
+        output_components=[Markdown],
+        port=8123,
+    )
+    seen = {}
+    monkeypatch.setattr(app.app, "run", lambda **kw: seen.update(kw))
+    app.run()
+    assert seen["port"] == 8123          # constructor port used by default
+    app.run(port=9000)
+    assert seen["port"] == 9000          # explicit run(port=) wins
+
+
 def test_dynamicdash_rejects_parent_without_resolver():
     with pytest.raises(ValueError, match="parent_control was given"):
         DynamicDash(

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -135,6 +135,32 @@ class TestBackendOptIn:
         assert "_mcp_mirror_store" in _layout_ids(app.app.layout)
 
     @requires_fastapi
+    @requires_dash_mcp
+    def test_fastapi_mcp_installs_request_context_middleware(self):
+        # #99: the native /mcp route needs the request context set on the ASGI
+        # backend (DashMiddleware skips non-/_dash- routes). enable_mcp installs
+        # a middleware to do that, or /mcp 500s.
+        from fast_dash.mcp import enable_mcp
+
+        app = self._fig_app(backend="fastapi")
+        enable_mcp(app)
+        names = [getattr(m.cls, "__name__", "") for m in app.app.server.user_middleware]
+        assert any("MCPRequestContext" in n for n in names)
+
+    def test_run_routes_to_asgi_on_backend(self, monkeypatch):
+        # #99: run() must serve the ASGI app via uvicorn, not Dash's
+        # frame-walking main-thread path.
+        app = self._fig_app(backend="fastapi") if _HAS_FASTAPI else None
+        if app is None:
+            import pytest as _pytest
+            _pytest.skip("fastapi not installed")
+        called = {}
+        monkeypatch.setattr(app, "_run_asgi", lambda: called.setdefault("asgi", True))
+        monkeypatch.setattr(app, "_start_mcp_server", lambda: None)
+        app.run()
+        assert called.get("asgi") is True
+
+    @requires_fastapi
     def test_stream_with_backend_uses_native_websocket(self):
         def fig(n: int = 3) -> go.Figure:
             return go.Figure()
@@ -243,7 +269,7 @@ class TestTools:
     def test_set_inputs_bulk(self):
         app = _plain_app()
         c = _client_for(app)
-        out = _call(c, "set_inputs", {"values": {"n": 4, "color": "#fff"}})
+        out = _call(c, "set_inputs", {"inputs": {"n": 4, "color": "#fff"}})
         assert out["ok"] is True
         assert app._mcp_state.pending_inputs == {"n": 4, "color": "#fff"}
 
@@ -254,6 +280,21 @@ class TestTools:
         assert out["ok"] is True
         assert out["outputs"]  # produced an output summary
         assert app._mcp_state.inputs["n"] == 4
+
+    def test_describe_app_typed_contract_and_readback(self):
+        # #102: typed contract from the callback signature; #100: read back the
+        # value an agent set (headless), which dash://components can't show.
+        app = _plain_app()  # plot_bars(n: int = 6, color: str = "#1c7ed6")
+        c = _client_for(app)
+        _call(c, "set_input", {"component_id": "n", "value": 9})
+        out = _call(c, "describe_app")
+        by_id = {i["id"]: i for i in out["inputs"]}
+        assert set(by_id) == {"n", "color"}            # contract names the params
+        assert by_id["n"]["type"] == "integer"
+        assert by_id["n"]["default"] == 6
+        assert by_id["n"]["current_value"] == 9        # reflects set_input
+        assert by_id["color"]["type"] == "string"
+        assert by_id["color"]["current_value"] == "#1c7ed6"  # seeded default
 
     def test_invoke_atomic_rejection(self):
         app = _plain_app()


### PR DESCRIPTION
Promotes 0.3.1 to release: the FastAPI-backend run-as-script blocker (#99), the describe_app read-back/contract tool (#100/#102), the set_inputs/DynamicDash-port nits, and the version+CHANGELOG bump. After merge, tagging v0.3.1 publishes to PyPI.