### PR TITLE
Fix #106: describe_app reflects DynamicDash set_form contract

### DIFF
--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -88,6 +88,11 @@ class MCPState:
         self.pending_inputs: dict[str, Any] = {}
         self.pending_specs: list[dict] | None = None
         self.pending_outputs: dict[str, Any] = {}
+        # The last form a set_form built. Unlike pending_specs (popped by the
+        # browser drain), this persists so describe_app can report the
+        # agent-generated form's contract — even after a browser renders it or
+        # a different agent reconnects.
+        self.current_specs: list[dict] | None = None
 
     def append_history(self, entry_summary: dict, entry_full: dict) -> int:
         self.history.append(entry_summary)
@@ -422,6 +427,9 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             except (TypeError, ValueError) as e:
                 return {"ok": False, "error": f"invalid spec: {e}", "spec": spec}
         state.pending_specs = specs
+        # Keep a persistent copy so describe_app can report the form contract
+        # (pending_specs is popped by the browser drain).
+        state.current_specs = specs
         return {"ok": True, "count": len(specs)}
 
     @mcp_enabled(name="get_invocation", expose_docstring=True)
@@ -500,9 +508,37 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
                     "options": _jsonify_for_mcp(options),
                     "current_value": _jsonify_for_mcp(cur),
                 })
+        elif state.current_specs:
+            # DynamicDash: report the agent-built form's contract from the specs
+            # set_form materialized, merged with any current values.
+            seen = set()
+            for spec in state.current_specs:
+                name = spec.get("name")
+                if not name:
+                    continue
+                seen.add(name)
+                props = spec.get("props") or {}
+                # Slider/number bounds, Select/MultiSelect options, etc. live in
+                # props; expose them so the contract is fully discoverable.
+                options = props.get("data")
+                default = spec.get("value", props.get("value"))
+                cur = snapshot.get(name, default)
+                inputs.append({
+                    "id": name,
+                    "tag": spec.get("type"),
+                    "type": spec.get("type"),
+                    "label": spec.get("label"),
+                    "default": _jsonify_for_mcp(default),
+                    "options": _jsonify_for_mcp(options),
+                    "props": _jsonify_for_mcp(props),
+                    "current_value": _jsonify_for_mcp(cur),
+                })
+            # Any extra mirror keys not in the form (defensive).
+            for k, v in snapshot.items():
+                if k not in seen:
+                    inputs.append({"id": k, "current_value": _jsonify_for_mcp(v)})
         else:
-            # DynamicDash / **kwargs callback: no static inputs — reflect the
-            # current mirror (whatever set_form/set_inputs populated).
+            # No form built yet — reflect whatever the mirror holds.
             for k, v in snapshot.items():
                 inputs.append({"id": k, "current_value": _jsonify_for_mcp(v)})
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -296,6 +296,25 @@ class TestTools:
         assert by_id["color"]["type"] == "string"
         assert by_id["color"]["current_value"] == "#1c7ed6"  # seeded default
 
+    def test_describe_app_reflects_dynamic_form(self):
+        # #106: after set_form, describe_app must report the agent-built form's
+        # contract (id/type/props), not just the value mirror.
+        app = _dynamic_app()
+        c = _client_for(app)
+        _call(c, "set_form", {"specs": [
+            {"name": "communication", "type": "Slider", "props": {"min": 0, "max": 10}},
+            {"name": "technical", "type": "Slider", "props": {"min": 0, "max": 10}},
+        ]})
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert set(by_id) == {"communication", "technical"}   # both discoverable
+        assert by_id["communication"]["type"] == "Slider"
+        assert by_id["communication"]["props"]["max"] == 10   # bounds exposed
+        # set one field — both still listed; current_value updated for the set one.
+        _call(c, "set_inputs", {"inputs": {"communication": 5}})
+        by_id2 = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert set(by_id2) == {"communication", "technical"}
+        assert by_id2["communication"]["current_value"] == 5
+
     def test_invoke_atomic_rejection(self):
         app = _plain_app()
         c = _client_for(app)


### PR DESCRIPTION
describe_app's DynamicDash branch mirrored only state.inputs, so an agent-built form (set_form) was drivable but undiscoverable (inputs:[] until a value was set; no type/default/props ever). Now MCPState.current_specs persists the form set_form built, and describe_app derives each field's id/type/label/default/options/props + current_value from it — fixing headless and cross-session discovery of agent-generated forms. Test added. Closes #106.