### PR TITLE
Release 0.3.2 - describe_app DynamicDash form (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# Release 0.3.1
+# Release 0.3.2
+
+## 0.3.2 (2026-06-26)
+
+### Bug fixes
+- **`describe_app()` now reports an agent-built DynamicDash form.** After an
+  agent calls `set_form`, `describe_app()` previously returned `inputs: []`
+  (the form was drivable but undiscoverable through the documented "start here"
+  tool). It now derives each field's `id`, `type`, `label`, `default`,
+  `options`, and `props` (e.g. a Slider's `min`/`max`/`step`) plus its current
+  value from the materialized form — so agent-generated UIs are discoverable
+  headlessly and across reconnecting sessions.
 
 ## 0.3.1 (2026-06-25)
 

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -88,6 +88,11 @@ class MCPState:
         self.pending_inputs: dict[str, Any] = {}
         self.pending_specs: list[dict] | None = None
         self.pending_outputs: dict[str, Any] = {}
+        # The last form a set_form built. Unlike pending_specs (popped by the
+        # browser drain), this persists so describe_app can report the
+        # agent-generated form's contract — even after a browser renders it or
+        # a different agent reconnects.
+        self.current_specs: list[dict] | None = None
 
     def append_history(self, entry_summary: dict, entry_full: dict) -> int:
         self.history.append(entry_summary)
@@ -422,6 +427,9 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             except (TypeError, ValueError) as e:
                 return {"ok": False, "error": f"invalid spec: {e}", "spec": spec}
         state.pending_specs = specs
+        # Keep a persistent copy so describe_app can report the form contract
+        # (pending_specs is popped by the browser drain).
+        state.current_specs = specs
         return {"ok": True, "count": len(specs)}
 
     @mcp_enabled(name="get_invocation", expose_docstring=True)
@@ -500,9 +508,37 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
                     "options": _jsonify_for_mcp(options),
                     "current_value": _jsonify_for_mcp(cur),
                 })
+        elif state.current_specs:
+            # DynamicDash: report the agent-built form's contract from the specs
+            # set_form materialized, merged with any current values.
+            seen = set()
+            for spec in state.current_specs:
+                name = spec.get("name")
+                if not name:
+                    continue
+                seen.add(name)
+                props = spec.get("props") or {}
+                # Slider/number bounds, Select/MultiSelect options, etc. live in
+                # props; expose them so the contract is fully discoverable.
+                options = props.get("data")
+                default = spec.get("value", props.get("value"))
+                cur = snapshot.get(name, default)
+                inputs.append({
+                    "id": name,
+                    "tag": spec.get("type"),
+                    "type": spec.get("type"),
+                    "label": spec.get("label"),
+                    "default": _jsonify_for_mcp(default),
+                    "options": _jsonify_for_mcp(options),
+                    "props": _jsonify_for_mcp(props),
+                    "current_value": _jsonify_for_mcp(cur),
+                })
+            # Any extra mirror keys not in the form (defensive).
+            for k, v in snapshot.items():
+                if k not in seen:
+                    inputs.append({"id": k, "current_value": _jsonify_for_mcp(v)})
         else:
-            # DynamicDash / **kwargs callback: no static inputs — reflect the
-            # current mirror (whatever set_form/set_inputs populated).
+            # No form built yet — reflect whatever the mirror holds.
             for k, v in snapshot.items():
                 inputs.append({"id": k, "current_value": _jsonify_for_mcp(v)})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.1"
+version = "0.3.2"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -296,6 +296,25 @@ class TestTools:
         assert by_id["color"]["type"] == "string"
         assert by_id["color"]["current_value"] == "#1c7ed6"  # seeded default
 
+    def test_describe_app_reflects_dynamic_form(self):
+        # #106: after set_form, describe_app must report the agent-built form's
+        # contract (id/type/props), not just the value mirror.
+        app = _dynamic_app()
+        c = _client_for(app)
+        _call(c, "set_form", {"specs": [
+            {"name": "communication", "type": "Slider", "props": {"min": 0, "max": 10}},
+            {"name": "technical", "type": "Slider", "props": {"min": 0, "max": 10}},
+        ]})
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert set(by_id) == {"communication", "technical"}   # both discoverable
+        assert by_id["communication"]["type"] == "Slider"
+        assert by_id["communication"]["props"]["max"] == 10   # bounds exposed
+        # set one field — both still listed; current_value updated for the set one.
+        _call(c, "set_inputs", {"inputs": {"communication": 5}})
+        by_id2 = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert set(by_id2) == {"communication", "technical"}
+        assert by_id2["communication"]["current_value"] == 5
+
     def test_invoke_atomic_rejection(self):
         app = _plain_app()
         c = _client_for(app)


### PR DESCRIPTION
Promotes 0.3.2 to release: describe_app now reports an agent-built DynamicDash form's contract (#106, merged via #107) plus the version+CHANGELOG bump. After merge, tagging v0.3.2 publishes to PyPI.