### PR TITLE
Fix #110: dropdown default seeds options as value (MCP mirror)

### DIFF
--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -219,7 +219,16 @@ def _seed_input_mirror(fd) -> None:
             if p.default is inspect.Parameter.empty:
                 continue
             if name in ids and name not in state.inputs:
-                state.inputs[name] = p.default
+                # A scalar default IS the value. A list/dict/range default is the
+                # component's *options* (dropdown / multi-select / slider
+                # bounds), not its value — the browser renders None there, so
+                # seed None (not the options) so describe_app's current_value is
+                # type-consistent and invoke() matches a UI Run (issue #110).
+                state.inputs[name] = (
+                    p.default
+                    if isinstance(p.default, (str, bool, int, float))
+                    else None
+                )
     except (TypeError, ValueError):
         pass
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -222,6 +222,19 @@ class TestSeed:
         assert app._mcp_state.inputs.get("name") == "world"
         assert app._mcp_state.inputs.get("count") == 3
 
+    def test_dropdown_default_seeds_none_not_options(self):
+        # #110: a str dropdown (list default) is options-as-default; its browser
+        # value is None, so the mirror must seed None, not the options list.
+        from fast_dash.mcp import _seed_input_mirror
+
+        def pick(fruit: str = ["a", "b", "c"], tags: list = ["x"], n: int = 6) -> str:
+            return str(fruit)
+        app = FastDash(callback_fn=pick, mcp_server=True)
+        _seed_input_mirror(app)
+        assert app._mcp_state.inputs["fruit"] is None    # not ["a","b","c"]
+        assert app._mcp_state.inputs["tags"] is None      # multiselect too
+        assert app._mcp_state.inputs["n"] == 6            # scalar still seeded
+
 
 # --- native mount + delegation --------------------------------------------- #
 
@@ -295,6 +308,22 @@ class TestTools:
         assert by_id["n"]["current_value"] == 9        # reflects set_input
         assert by_id["color"]["type"] == "string"
         assert by_id["color"]["current_value"] == "#1c7ed6"  # seeded default
+
+    def test_dropdown_contract_consistent_and_invoke_parity(self):
+        # #110: describe_app current_value is type-consistent (None, not a list),
+        # and invoke() with defaults passes None (the browser's value), not the
+        # options list — so a str param never silently receives a list.
+        def pick(fruit: str = ["a", "b", "c"]) -> str:
+            """Echo the type."""
+            return type(fruit).__name__
+        app = FastDash(callback_fn=pick, mcp_server=True)
+        c = _client_for(app)
+        fruit = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}["fruit"]
+        assert fruit["type"] == "string"
+        assert fruit["current_value"] is None           # not the options list
+        assert fruit["options"] == ["a", "b", "c"]
+        out = _call(c, "invoke")
+        assert "NoneType" in json.dumps(out["outputs"])  # callback got None
 
     def test_describe_app_reflects_dynamic_form(self):
         # #106: after set_form, describe_app must report the agent-built form's


### PR DESCRIPTION
Fixes the dropdown-seeding bug the nightly routine filed (#110), and supersedes the community PR #111 (thanks @muhamedfazalps for the report and the fix attempt).

## Root cause
A `str` parameter with a list default (`fruit: str = ["a","b","c"]`) is a **single-select dropdown** whose *options* are the list and whose *value* is `None` (the browser renders nothing selected). The MCP input mirror's signature-default fallback seeded the **whole options list** as the current value. So:
- `describe_app()` returned `type: "string"` with `current_value: ["a","b","c"]` (a list) — self-contradictory.
- `invoke()` with defaults passed a `list` to a `str` param, while the browser's Run passes `None`. Human↔agent parity broken.

## Fix
`_seed_input_mirror` now seeds a **scalar** default as the value, and seeds **`None`** for a list/dict/range default (those are the component's *options*, not its value). After the fix:
- `describe_app` → `current_value: None` (type-consistent; matches the browser's `value: null`), with the list still reported under `options`.
- `invoke()` with defaults runs the callback with `None` — identical to a UI Run.

Scalar inputs are unaffected (their component `value` prop is already seeded by the first pass).

## On #111
@muhamedfazalps correctly spotted the list-default seeding problem. Two reasons this lands differently:
1. The fix belongs in **`_seed_input_mirror`** (the seed feeds both `describe_app`'s `current_value` *and* `invoke()`), not in `describe_app`'s `default` field — changing `default` alone leaves `current_value` and `invoke()` still passing the list.
2. The issue's browser-truth evidence shows the dropdown value is **`null`**, not the first option — so the correct value is `None`, not `options[0]`.

Also, #111 targets the stale `main` branch (active development is on `dev` / `release`), which is why its diff is +10912/−2921.

## Tests
`_seed_input_mirror` seeds `None` for dropdown/multiselect (scalars still seed); `describe_app` type-consistency + `invoke()`-vs-browser parity.

Closes #110.
