### PR TITLE
Release prep 0.3.3 (#110 dropdown seeding fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# Release 0.3.2
+# Release 0.3.3
+
+## 0.3.3 (2026-06-27)
+
+### Bug fixes
+- **A single-select dropdown (`str` with a list default) no longer seeds its
+  *options* as its value over MCP.** Previously the input mirror seeded the
+  whole options list, so `describe_app()` reported a `list` `current_value`
+  under `type: "string"`, and `invoke()` with defaults passed a `list` to a
+  `str` parameter while the browser held `None`. The mirror now seeds `None`
+  for list/dict/range defaults (those are the component's options, not its
+  value), so `describe_app`'s `current_value` is type-consistent and `invoke()`
+  matches a UI Run. Thanks to @muhamedfazalps for the report. (#110)
 
 ## 0.3.2 (2026-06-26)
 

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 from fast_dash.Components import (
     Graph,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.2"
+version = "0.3.3"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."


### PR DESCRIPTION
Version bump 0.3.2 -> 0.3.3 + CHANGELOG for the #110 fix already merged via #112. Version + changelog only. After this: dev -> release, then tag v0.3.3 to publish.