### PR TITLE
Release 0.3.3 - dropdown seeding fix (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
-# Release 0.3.2
+# Release 0.3.3
+
+## 0.3.3 (2026-06-27)
+
+### Bug fixes
+- **A single-select dropdown (`str` with a list default) no longer seeds its
+  *options* as its value over MCP.** Previously the input mirror seeded the
+  whole options list, so `describe_app()` reported a `list` `current_value`
+  under `type: "string"`, and `invoke()` with defaults passed a `list` to a
+  `str` parameter while the browser held `None`. The mirror now seeds `None`
+  for list/dict/range defaults (those are the component's options, not its
+  value), so `describe_app`'s `current_value` is type-consistent and `invoke()`
+  matches a UI Run. Thanks to @muhamedfazalps for the report. (#110)
 
 ## 0.3.2 (2026-06-26)
 

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.2"
+__version__ = "0.3.3"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -219,7 +219,16 @@ def _seed_input_mirror(fd) -> None:
             if p.default is inspect.Parameter.empty:
                 continue
             if name in ids and name not in state.inputs:
-                state.inputs[name] = p.default
+                # A scalar default IS the value. A list/dict/range default is the
+                # component's *options* (dropdown / multi-select / slider
+                # bounds), not its value — the browser renders None there, so
+                # seed None (not the options) so describe_app's current_value is
+                # type-consistent and invoke() matches a UI Run (issue #110).
+                state.inputs[name] = (
+                    p.default
+                    if isinstance(p.default, (str, bool, int, float))
+                    else None
+                )
     except (TypeError, ValueError):
         pass
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.2"
+version = "0.3.3"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -222,6 +222,19 @@ class TestSeed:
         assert app._mcp_state.inputs.get("name") == "world"
         assert app._mcp_state.inputs.get("count") == 3
 
+    def test_dropdown_default_seeds_none_not_options(self):
+        # #110: a str dropdown (list default) is options-as-default; its browser
+        # value is None, so the mirror must seed None, not the options list.
+        from fast_dash.mcp import _seed_input_mirror
+
+        def pick(fruit: str = ["a", "b", "c"], tags: list = ["x"], n: int = 6) -> str:
+            return str(fruit)
+        app = FastDash(callback_fn=pick, mcp_server=True)
+        _seed_input_mirror(app)
+        assert app._mcp_state.inputs["fruit"] is None    # not ["a","b","c"]
+        assert app._mcp_state.inputs["tags"] is None      # multiselect too
+        assert app._mcp_state.inputs["n"] == 6            # scalar still seeded
+
 
 # --- native mount + delegation --------------------------------------------- #
 
@@ -295,6 +308,22 @@ class TestTools:
         assert by_id["n"]["current_value"] == 9        # reflects set_input
         assert by_id["color"]["type"] == "string"
         assert by_id["color"]["current_value"] == "#1c7ed6"  # seeded default
+
+    def test_dropdown_contract_consistent_and_invoke_parity(self):
+        # #110: describe_app current_value is type-consistent (None, not a list),
+        # and invoke() with defaults passes None (the browser's value), not the
+        # options list — so a str param never silently receives a list.
+        def pick(fruit: str = ["a", "b", "c"]) -> str:
+            """Echo the type."""
+            return type(fruit).__name__
+        app = FastDash(callback_fn=pick, mcp_server=True)
+        c = _client_for(app)
+        fruit = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}["fruit"]
+        assert fruit["type"] == "string"
+        assert fruit["current_value"] is None           # not the options list
+        assert fruit["options"] == ["a", "b", "c"]
+        out = _call(c, "invoke")
+        assert "NoneType" in json.dumps(out["outputs"])  # callback got None
 
     def test_describe_app_reflects_dynamic_form(self):
         # #106: after set_form, describe_app must report the agent-built form's


### PR DESCRIPTION
Promotes 0.3.3 to release: the dropdown/multiselect options-as-value seeding fix (#110, merged via #112) + version/CHANGELOG bump. After merge, tagging v0.3.3 publishes to PyPI.