### PR TITLE
docs: note describe_app reflects an agent-built DynamicDash form (0.3.2)

### DIFF
--- a/docs/User guide/ai_agents.md
+++ b/docs/User guide/ai_agents.md
@@ -113,6 +113,12 @@ set_form([
 ])
 ```
 
+After `set_form`, **`describe_app()` reflects the materialized form** — each field's
+`id`, `type`, `default`, `options`, and `props` (e.g. a slider's `min`/`max`) plus
+its current value — so a reconnecting (or second) agent can discover and drive the
+form without remembering the spec it sent. From there, `set_inputs(...)` + `invoke()`
+run it.
+
 ## Real-time push (opt-in)
 
 On the default Flask backend, agent mutations reach the browser via a ~500 ms


### PR DESCRIPTION
## What

Adds a 4-line note to the AI-agents guide closing the DynamicDash discovery loop: after an agent calls `set_form`, **`describe_app()` reflects the materialized form** (id, type, default, options, props + current value), so a reconnecting or second agent can discover and drive it without remembering the spec it sent.

## Why

This documents the **0.3.2** behavior (`describe_app()` reports an agent-built DynamicDash form). The changelog described it but the guide's DynamicDash section showed `set_form` and stopped — never told the agent it could read the form back. Docs-only; no code change, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
