### PR TITLE
fix: expose static Slider min/max/step in describe_app + range validation (#120)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
-# Release 0.3.4
+# Release 0.3.5
 
-## 0.3.4 (2026-06-28)
+## 0.3.5 (2026-06-29)
+
+### Bug fixes
+- **`describe_app()` now exposes a static Slider's `min`/`max`/`step`.** A
+  `Slider` input (`Annotated[int, range(...)]` or an `int = range(...)` default)
+  is hard-bounded in the UI, but for a static `FastDash` app the contract
+  reported it as a generic unbounded number (no `props`), so a headless agent
+  couldn't discover or stay within the range. The contract now carries a
+  `props: {min, max, step}` block for bounded widgets (mirroring what DynamicDash
+  forms already expose); a genuinely unbounded number box still reports no
+  bounds. (#120)
+
+### Changed
+- **`set_input` / `set_inputs` / `invoke` reject out-of-range Slider values.**
+  Extending the 0.3.4 options validation: a numeric value outside a Slider's
+  `min`/`max` (e.g. `99999` on a `range(0, 100)` slider) is now rejected with a
+  clear error, the way a UI slider physically can't emit it — completing the
+  human<->agent parity for numeric inputs. Unbounded inputs stay permissive and
+  `invoke` remains atomic. (#120)
 
 ### Bug fixes
 - **`describe_app()` no longer leaks a `depends_on` object repr, and resolves a

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -276,19 +276,43 @@ def _resolve_depends_on_options(fd, dep, snapshot):
     return list(data) if isinstance(data, list) else None
 
 
+def _component_bounds(comp):
+    """Numeric ``{min, max, step}`` carried by a Slider/number component, else {}.
+
+    A Slider built from ``Annotated[int, range(...)]`` / an ``int = range(...)``
+    default stores hard ``min`` / ``max`` / ``step`` props; a plain number box
+    sets none. Surfacing them lets a headless agent discover (and stay within) a
+    slider's range, the same way DynamicDash forms already expose their props
+    (issue #120).
+    """
+    if comp is None:
+        return {}
+    props = {}
+    for k in ("min", "max", "step"):
+        v = getattr(comp, k, None)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            props[k] = v
+    return props
+
+
 def _describe_static_inputs(fd, snapshot):
     """Per-input contract for a static FastDash app.
 
-    Single source of truth for ``describe_app`` and the option validators, so a
+    Single source of truth for ``describe_app`` and the value validators, so a
     headless agent's contract matches what ``set_input`` / ``invoke`` enforce
     (human<->agent parity). Each entry is ``{id, tag, type, default, options,
-    current_value}``. Resolves ``depends_on`` / list / dict / ``Literal`` /
-    ``Enum`` defaults into clean JSON and **never** leaks an object ``repr`` into
-    a contract field (issue #116).
+    current_value}`` plus a ``props`` block when the widget carries numeric
+    bounds. Resolves ``depends_on`` / list / dict / ``Literal`` / ``Enum``
+    defaults into clean JSON and **never** leaks an object ``repr`` into a
+    contract field (issue #116).
     """
     from fast_dash.utils import _jsonify_for_mcp, depends_on
 
     descriptors = _enumerate_inputs(fd)
+    components = {
+        _stringify_id(c.id): c
+        for c in (getattr(fd, "inputs_with_ids", None) or [])
+    }
     try:
         sig_params = dict(inspect.signature(fd.callback_fn).parameters)
     except (TypeError, ValueError):
@@ -330,39 +354,54 @@ def _describe_static_inputs(fd, snapshot):
                 # else (range / arbitrary objects): leave default None so the
                 # contract never carries a non-JSON repr (issue #116).
         cur = snapshot.get(cid, snapshot.get(param))
-        contract.append({
+        entry = {
             "id": cid,
             "tag": d["tag"],
             "type": jtype,
             "default": _jsonify_for_mcp(default),
             "options": _jsonify_for_mcp(options),
             "current_value": _jsonify_for_mcp(cur),
-        })
+        }
+        bounds = _component_bounds(components.get(cid))
+        if bounds:
+            entry["props"] = bounds                   # Slider min/max/step (issue #120)
+        contract.append(entry)
     return contract
 
 
 def _option_error(fd, component_id, value, snapshot):
-    """Reject a value that violates an input's advertised ``options``, else None.
+    """Reject a value the UI could never produce, else None.
 
     Validates against the very contract ``describe_app`` reports (parity), so an
-    agent can never set a value the UI ``Select`` could not produce (issue
-    #116). Permissive by design: an input with no advertised options accepts any
-    value, and ``None`` always clears a selection. For a MultiSelect (list
-    value) every element must be a legal key.
+    agent can never set a value the UI widget couldn't: a value outside a
+    dropdown's ``options`` (issue #116) or outside a Slider's ``min``/``max``
+    bounds (issue #120). Permissive by design: an input with neither advertised
+    options nor bounds accepts any value, and ``None`` always clears a
+    selection. For a MultiSelect (list value) every element must be a legal key.
     """
     for entry in _describe_static_inputs(fd, snapshot):
         if entry["id"] != component_id:
             continue
+        if value is None:
+            return None
         options = entry.get("options")
-        if not options or value is None:
+        if options:
+            if isinstance(value, (list, tuple)):
+                bad = [v for v in value if v not in options]
+                if bad:
+                    return f"value(s) {bad} not in allowed options {options}"
+                return None
+            if value not in options:
+                return f"value {value!r} not in allowed options {options}"
             return None
-        if isinstance(value, (list, tuple)):
-            bad = [v for v in value if v not in options]
-            if bad:
-                return f"value(s) {bad} not in allowed options {options}"
-            return None
-        if value not in options:
-            return f"value {value!r} not in allowed options {options}"
+        # Numeric Slider bounds (no options): reject out-of-range, like the UI.
+        props = entry.get("props") or {}
+        lo, hi = props.get("min"), props.get("max")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if lo is not None and value < lo:
+                return f"value {value} is below the minimum {lo}"
+            if hi is not None and value > hi:
+                return f"value {value} is above the maximum {hi}"
         return None
     return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.4"
+version = "0.3.5"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/_slider_app.py
+++ b/tests/_slider_app.py
@@ -1,0 +1,20 @@
+"""Helper callback for the #120 Slider-bounds test.
+
+Deliberately has **no** ``from __future__ import annotations`` so the documented
+slider type hints resolve to real ``range`` / ``Annotated`` objects at
+inference time — i.e. the exact way a user's plain script (the issue's repro)
+builds the app. (Defining it inside the future-annotations ``test_mcp`` module
+would stringify the annotations and degrade the widget; that's the separate
+issue #119.)
+"""
+
+from typing import Annotated
+
+
+def slider_demo(
+    via_annot: Annotated[int, range(0, 100)] = 30,   # Annotated[int, range] -> Slider
+    via_range: int = range(0, 100),                  # int with range() default -> Slider
+    plain_num: int = 5,                              # int -> NumberInput (unbounded)
+) -> str:
+    """Echo the three numeric inputs."""
+    return f"{via_annot} {via_range} {plain_num}"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -368,6 +368,36 @@ class TestTools:
         # and no raw object repr leaks into the default contract field.
         assert items["default"] is None
 
+    def test_slider_bounds_in_contract_and_range_validation(self):
+        # #120: a static Slider must expose its min/max/step in the contract (so
+        # an agent can discover the range), and set_input/invoke must reject
+        # out-of-range values the UI slider can never produce (parity). The
+        # callback lives in a plain module (see tests/_slider_app.py) so the
+        # documented slider hints aren't stringified by this module's future
+        # annotations (that degradation is the separate issue #119).
+        from tests._slider_app import slider_demo
+        app = FastDash(callback_fn=slider_demo, mcp_server=True)
+        c = _client_for(app)
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+
+        # bounded sliders expose props; the plain number box does not.
+        assert by_id["via_annot"]["props"] == {"min": 0, "max": 100, "step": 1}
+        assert by_id["via_range"]["props"] == {"min": 0, "max": 100, "step": 1}
+        assert "props" not in by_id["plain_num"]          # genuinely unbounded
+
+        # out-of-range rejected; in-range accepted; unbounded input stays free.
+        hi = _call(c, "set_input", {"component_id": "via_annot", "value": 99999})
+        assert hi["ok"] is False and "maximum" in hi["error"]
+        lo = _call(c, "set_input", {"component_id": "via_annot", "value": -50})
+        assert lo["ok"] is False and "minimum" in lo["error"]
+        assert _call(c, "set_input", {"component_id": "via_annot", "value": 42})["ok"]
+        assert _call(c, "set_input", {"component_id": "plain_num", "value": 99999})["ok"]
+
+        # invoke stays atomic: an out-of-range value rejects without mutating.
+        out = _call(c, "invoke", {"inputs": {"via_annot": 99999}})
+        assert out["ok"] is False and out["errors"]["via_annot"]
+        assert app._mcp_state.inputs["via_annot"] == 42   # unchanged from set_input
+
     def test_set_input_and_invoke_validate_against_options(self):
         # #116 (note): a value the UI Select can never produce must be rejected,
         # mirroring the unknown-id guard (human<->agent parity). Valid values and


### PR DESCRIPTION
Fixes #120 (filed by the nightly dogfood routine).

## The bug

A static `FastDash` `Slider` (`Annotated[int, range(0,100)]` or `int = range(0,100)`) is hard-bounded in the UI, but `describe_app()` — the documented "Start here" agent contract — reported it as a generic unbounded number (`type: integer`, `options: null`, **no props**). So a headless agent:

1. couldn't tell a bounded slider from a free number box, and
2. got no validation — `set_input`/`invoke` accepted `99999` / `-50`, values the UI slider can never emit.

Same contract-correctness / parity class as #110 / #116 and the 0.3.4 options-validation change. The capability already existed (DynamicDash sliders surface their bounds); only the static path dropped them.

## The fix

- **Bounds in the contract.** The static-input builder now reads `min`/`max`/`step` straight off the inferred component and emits a `props` block when present — mirroring DynamicDash. A genuinely unbounded number box still reports no bounds, so the two stay distinguishable.
- **Range validation (parity).** `set_input`/`set_inputs`/`invoke` reject out-of-range numeric values when the input has bounds, extending the 0.3.4 options validation. Unbounded inputs stay permissive; `invoke` remains atomic.

Both fall out of the single `_describe_static_inputs` source of truth shared by `describe_app` and the validators.

## Verification

Reproduced #120's exact "Expected": `via_annot`/`via_range` now carry `props: {min:0, max:100, step:1}`, `plain_num` carries none, and `set_input via_annot=99999` is rejected (`above the maximum 100`).

The test callback lives in a plain `tests/_slider_app.py` (no `from __future__ import annotations`) so the documented slider hints resolve to real `range`/`Annotated` objects — exactly how a user's plain script (the issue's repro) builds the app. **62 passed.**

Bumps `0.3.4 → 0.3.5`.

> Note: defining the same slider *inside* this repo's future-annotations `test_mcp` module would stringify the hints and degrade the widget to a number box — that annotation-inference degradation is the separate **#119**, not this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
