### PR TITLE
fix: resolve string annotations so PEP 563 doesn't degrade inference (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## 0.3.5 (2026-06-29)
 
 ### Bug fixes
+- **Type-hint inference no longer degrades under `from __future__ import
+  annotations`.** With PEP 563 enabled, every annotation reaches inference as a
+  string (`"dict"`, `"list"`, `"Annotated[int, range(...)]"`), so a `dict` input
+  silently rendered as a Text box instead of a multi-select, a `list`-defaulted
+  `str` as a Text box instead of a dropdown, and `Annotated[int, range(...)]` /
+  `int = range(...)` as a Text box instead of a Slider. fast_dash now resolves
+  annotations (via `get_type_hints`, preserving `Annotated` metadata) before
+  building components, with a per-parameter fallback so one unresolvable
+  annotation (e.g. a forward-ref return type) doesn't degrade the other inputs.
+  (#119)
 - **`describe_app()` now exposes a static Slider's `min`/`max`/`step`.** A
   `Slider` input (`Annotated[int, range(...)]` or an `int = range(...)` default)
   is hard-bounded in the UI, but for a static `FastDash` app the contract

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -8,7 +8,7 @@ import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import Any, Union, Literal, Annotated, get_origin, get_args
+from typing import Any, Union, Literal, Annotated, get_origin, get_args, get_type_hints
 
 import dash
 from dash import Input, Output, State, dcc, html, ctx, Patch
@@ -1243,9 +1243,33 @@ def _infer_input_components(func):
     signature = inspect.signature(func)
     components = []
 
+    # Resolve string annotations to real types before dispatching on them.
+    # Under ``from __future__ import annotations`` (PEP 563) every annotation is
+    # a string, so ``parameter.annotation`` is e.g. ``"dict"`` instead of
+    # ``dict`` and component inference falls through to a Text box (issue #119).
+    # Prefer ``get_type_hints`` (handles forward refs; ``include_extras=True``
+    # keeps ``Annotated[int, range(...)]`` metadata so Slider inference works).
+    # If it raises on *any* one annotation (commonly an unresolvable return type
+    # like ``-> "Figure"``), fall back to resolving each *parameter* annotation
+    # independently so one bad hint doesn't degrade every input; keep the raw
+    # annotation when even that fails.
+    func_globals = getattr(func, "__globals__", {})
+    try:
+        resolved_hints = get_type_hints(func, include_extras=True)
+    except Exception:
+        resolved_hints = {}
+        for pname, pobj in signature.parameters.items():
+            ann = pobj.annotation
+            if isinstance(ann, str):
+                try:
+                    ann = eval(ann, func_globals)  # noqa: S307 - user's own annotation, user's own module
+                except Exception:
+                    ann = pobj.annotation
+            resolved_hints[pname] = ann
+
     parameters = signature.parameters.items()
-    for _, value in parameters:
-        hint = value.annotation
+    for name, value in parameters:
+        hint = resolved_hints.get(name, value.annotation)
         default = None if value.default == inspect._empty else value.default
 
         # Handle depends_on defaults — reactive input wired to a parent input

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+from typing import Annotated  # module-level so get_type_hints can resolve it (#119)
 
 import pandas as pd  # noqa: F401  (module-level for any -> pd.DataFrame hints)
 import plotly.graph_objects as go
@@ -367,14 +368,47 @@ class TestTools:
         assert items["options"] == ["apples", "pears", "figs"]
         # and no raw object repr leaks into the default contract field.
         assert items["default"] is None
+        # #119: now that future annotations no longer degrade inference, the dict
+        # builds a real MultiSelect (no value), so current_value is a clean None.
+        assert items["current_value"] is None
+
+    def test_future_annotations_do_not_degrade_inference(self):
+        # #119: this module uses `from __future__ import annotations`, so every
+        # annotation below reaches component inference as a *string* ("dict",
+        # "list", "Annotated[...]"). Inference must resolve them (get_type_hints)
+        # rather than fall through to a Text box — so a dict stays a MultiSelect,
+        # a list a Select, and Annotated[int, range] a bounded Slider. (This also
+        # restores the #120 slider contract under future annotations.)
+        def cfg(
+            items: dict = {"a": 1, "b": 2},
+            fruit: str = ["x", "y", "z"],
+            level: Annotated[int, range(0, 10)] = 3,
+            free: str = "hi",
+        ) -> str:
+            """Echo."""
+            return "ok"
+
+        app = FastDash(callback_fn=cfg, mcp_server=True)
+        c = _client_for(app)
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+
+        assert by_id["items"]["options"] == ["a", "b"]        # dict -> MultiSelect keys
+        assert by_id["items"]["current_value"] is None        # real widget, not a text box
+        assert by_id["fruit"]["options"] == ["x", "y", "z"]   # list -> Select dropdown
+        assert by_id["level"]["props"] == {"min": 0, "max": 10, "step": 1}  # Slider bounds
+        assert "props" not in by_id["free"]                   # plain str stays free text
+        assert by_id["free"]["options"] is None
+        # the resolved Slider's bounds are enforced too.
+        assert _call(c, "set_input", {"component_id": "level", "value": 99})["ok"] is False
 
     def test_slider_bounds_in_contract_and_range_validation(self):
         # #120: a static Slider must expose its min/max/step in the contract (so
         # an agent can discover the range), and set_input/invoke must reject
         # out-of-range values the UI slider can never produce (parity). The
-        # callback lives in a plain module (see tests/_slider_app.py) so the
-        # documented slider hints aren't stringified by this module's future
-        # annotations (that degradation is the separate issue #119).
+        # callback lives in a plain module (tests/_slider_app.py) — a faithful
+        # copy of the issue's plain-script repro. (Sliders defined inline here
+        # also work now that #119 resolves future annotations; the inline test
+        # above covers that path.)
         from tests._slider_app import slider_demo
         app = FastDash(callback_fn=slider_demo, mcp_server=True)
         c = _client_for(app)


### PR DESCRIPTION
Fixes #119 (filed as a follow-up while resolving #116).

## The bug

Under `from __future__ import annotations` (PEP 563 — increasingly the default style), every annotation reaches component inference as a **string**. `_infer_input_components` dispatched on that raw string and fell through to a Text box:

| Hint | Without future annotations | With future annotations (bug) |
|---|---|---|
| `items: dict = {...}` | MultiSelect (keys) | Text box showing `"{...}"` |
| `fruit: str = [...]` | Select dropdown | Text box |
| `Annotated[int, range(0,100)]` / `int = range(0,100)` | Slider | Text box |

Silent — no error, just the wrong widget. It also suppressed #120's slider bounds under future annotations.

## The fix

`_infer_input_components` now resolves annotations before building components:

- **`get_type_hints(func, include_extras=True)`** — resolves the strings to real types, keeping `Annotated[...]` metadata so Slider inference still works.
- **Per-parameter fallback** — if `get_type_hints` raises on any single annotation (commonly an unresolvable *return* type like `-> "Figure"`), each parameter annotation is resolved independently so one bad hint doesn't degrade every input. Raw annotation kept if even that fails (no regression).

## Verification

- Repro now recovers: `dict`→MultiSelect, `list`→Select, `Annotated[int, range]` / `int=range`→Slider (with bounds), `int`→unbounded number box.
- Robustness: a function with an unresolvable return annotation still resolves its `dict` input to a MultiSelect.
- New inline #119 regression test (this module uses future annotations); re-strengthened the #116 dict test now that the widget no longer degrades.
- **Inference suite: 92 passed. MCP + dynamic: 63 passed.** No regressions in `test_typing_hints` / `test_plotly_string_annotation`.

No version bump — ships with **0.3.5** alongside #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
