### PR TITLE
Release 0.3.5 — Slider bounds (#120) + future-annotations inference (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 ## 0.3.5 (2026-06-29)
 
 ### Bug fixes
+- **Type-hint inference no longer degrades under `from __future__ import
+  annotations`.** With PEP 563 enabled, every annotation reaches inference as a
+  string (`"dict"`, `"list"`, `"Annotated[int, range(...)]"`), so a `dict` input
+  silently rendered as a Text box instead of a multi-select, a `list`-defaulted
+  `str` as a Text box instead of a dropdown, and `Annotated[int, range(...)]` /
+  `int = range(...)` as a Text box instead of a Slider. fast_dash now resolves
+  annotations (via `get_type_hints`, preserving `Annotated` metadata) before
+  building components, with a per-parameter fallback so one unresolvable
+  annotation (e.g. a forward-ref return type) doesn't degrade the other inputs.
+  (#119)
 - **`describe_app()` now exposes a static Slider's `min`/`max`/`step`.** A
   `Slider` input (`Annotated[int, range(...)]` or an `int = range(...)` default)
   is hard-bounded in the UI, but for a static `FastDash` app the contract

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,24 @@
-# Release 0.3.4
+# Release 0.3.5
 
-## 0.3.4 (2026-06-28)
+## 0.3.5 (2026-06-29)
+
+### Bug fixes
+- **`describe_app()` now exposes a static Slider's `min`/`max`/`step`.** A
+  `Slider` input (`Annotated[int, range(...)]` or an `int = range(...)` default)
+  is hard-bounded in the UI, but for a static `FastDash` app the contract
+  reported it as a generic unbounded number (no `props`), so a headless agent
+  couldn't discover or stay within the range. The contract now carries a
+  `props: {min, max, step}` block for bounded widgets (mirroring what DynamicDash
+  forms already expose); a genuinely unbounded number box still reports no
+  bounds. (#120)
+
+### Changed
+- **`set_input` / `set_inputs` / `invoke` reject out-of-range Slider values.**
+  Extending the 0.3.4 options validation: a numeric value outside a Slider's
+  `min`/`max` (e.g. `99999` on a `range(0, 100)` slider) is now rejected with a
+  clear error, the way a UI slider physically can't emit it — completing the
+  human<->agent parity for numeric inputs. Unbounded inputs stay permissive and
+  `invoke` remains atomic. (#120)
 
 ### Bug fixes
 - **`describe_app()` no longer leaks a `depends_on` object repr, and resolves a

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -8,7 +8,7 @@ import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
 from functools import reduce
-from typing import Any, Union, Literal, Annotated, get_origin, get_args
+from typing import Any, Union, Literal, Annotated, get_origin, get_args, get_type_hints
 
 import dash
 from dash import Input, Output, State, dcc, html, ctx, Patch
@@ -1243,9 +1243,33 @@ def _infer_input_components(func):
     signature = inspect.signature(func)
     components = []
 
+    # Resolve string annotations to real types before dispatching on them.
+    # Under ``from __future__ import annotations`` (PEP 563) every annotation is
+    # a string, so ``parameter.annotation`` is e.g. ``"dict"`` instead of
+    # ``dict`` and component inference falls through to a Text box (issue #119).
+    # Prefer ``get_type_hints`` (handles forward refs; ``include_extras=True``
+    # keeps ``Annotated[int, range(...)]`` metadata so Slider inference works).
+    # If it raises on *any* one annotation (commonly an unresolvable return type
+    # like ``-> "Figure"``), fall back to resolving each *parameter* annotation
+    # independently so one bad hint doesn't degrade every input; keep the raw
+    # annotation when even that fails.
+    func_globals = getattr(func, "__globals__", {})
+    try:
+        resolved_hints = get_type_hints(func, include_extras=True)
+    except Exception:
+        resolved_hints = {}
+        for pname, pobj in signature.parameters.items():
+            ann = pobj.annotation
+            if isinstance(ann, str):
+                try:
+                    ann = eval(ann, func_globals)  # noqa: S307 - user's own annotation, user's own module
+                except Exception:
+                    ann = pobj.annotation
+            resolved_hints[pname] = ann
+
     parameters = signature.parameters.items()
-    for _, value in parameters:
-        hint = value.annotation
+    for name, value in parameters:
+        hint = resolved_hints.get(name, value.annotation)
         default = None if value.default == inspect._empty else value.default
 
         # Handle depends_on defaults — reactive input wired to a parent input

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.4"
+__version__ = "0.3.5"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -276,19 +276,43 @@ def _resolve_depends_on_options(fd, dep, snapshot):
     return list(data) if isinstance(data, list) else None
 
 
+def _component_bounds(comp):
+    """Numeric ``{min, max, step}`` carried by a Slider/number component, else {}.
+
+    A Slider built from ``Annotated[int, range(...)]`` / an ``int = range(...)``
+    default stores hard ``min`` / ``max`` / ``step`` props; a plain number box
+    sets none. Surfacing them lets a headless agent discover (and stay within) a
+    slider's range, the same way DynamicDash forms already expose their props
+    (issue #120).
+    """
+    if comp is None:
+        return {}
+    props = {}
+    for k in ("min", "max", "step"):
+        v = getattr(comp, k, None)
+        if isinstance(v, (int, float)) and not isinstance(v, bool):
+            props[k] = v
+    return props
+
+
 def _describe_static_inputs(fd, snapshot):
     """Per-input contract for a static FastDash app.
 
-    Single source of truth for ``describe_app`` and the option validators, so a
+    Single source of truth for ``describe_app`` and the value validators, so a
     headless agent's contract matches what ``set_input`` / ``invoke`` enforce
     (human<->agent parity). Each entry is ``{id, tag, type, default, options,
-    current_value}``. Resolves ``depends_on`` / list / dict / ``Literal`` /
-    ``Enum`` defaults into clean JSON and **never** leaks an object ``repr`` into
-    a contract field (issue #116).
+    current_value}`` plus a ``props`` block when the widget carries numeric
+    bounds. Resolves ``depends_on`` / list / dict / ``Literal`` / ``Enum``
+    defaults into clean JSON and **never** leaks an object ``repr`` into a
+    contract field (issue #116).
     """
     from fast_dash.utils import _jsonify_for_mcp, depends_on
 
     descriptors = _enumerate_inputs(fd)
+    components = {
+        _stringify_id(c.id): c
+        for c in (getattr(fd, "inputs_with_ids", None) or [])
+    }
     try:
         sig_params = dict(inspect.signature(fd.callback_fn).parameters)
     except (TypeError, ValueError):
@@ -330,39 +354,54 @@ def _describe_static_inputs(fd, snapshot):
                 # else (range / arbitrary objects): leave default None so the
                 # contract never carries a non-JSON repr (issue #116).
         cur = snapshot.get(cid, snapshot.get(param))
-        contract.append({
+        entry = {
             "id": cid,
             "tag": d["tag"],
             "type": jtype,
             "default": _jsonify_for_mcp(default),
             "options": _jsonify_for_mcp(options),
             "current_value": _jsonify_for_mcp(cur),
-        })
+        }
+        bounds = _component_bounds(components.get(cid))
+        if bounds:
+            entry["props"] = bounds                   # Slider min/max/step (issue #120)
+        contract.append(entry)
     return contract
 
 
 def _option_error(fd, component_id, value, snapshot):
-    """Reject a value that violates an input's advertised ``options``, else None.
+    """Reject a value the UI could never produce, else None.
 
     Validates against the very contract ``describe_app`` reports (parity), so an
-    agent can never set a value the UI ``Select`` could not produce (issue
-    #116). Permissive by design: an input with no advertised options accepts any
-    value, and ``None`` always clears a selection. For a MultiSelect (list
-    value) every element must be a legal key.
+    agent can never set a value the UI widget couldn't: a value outside a
+    dropdown's ``options`` (issue #116) or outside a Slider's ``min``/``max``
+    bounds (issue #120). Permissive by design: an input with neither advertised
+    options nor bounds accepts any value, and ``None`` always clears a
+    selection. For a MultiSelect (list value) every element must be a legal key.
     """
     for entry in _describe_static_inputs(fd, snapshot):
         if entry["id"] != component_id:
             continue
+        if value is None:
+            return None
         options = entry.get("options")
-        if not options or value is None:
+        if options:
+            if isinstance(value, (list, tuple)):
+                bad = [v for v in value if v not in options]
+                if bad:
+                    return f"value(s) {bad} not in allowed options {options}"
+                return None
+            if value not in options:
+                return f"value {value!r} not in allowed options {options}"
             return None
-        if isinstance(value, (list, tuple)):
-            bad = [v for v in value if v not in options]
-            if bad:
-                return f"value(s) {bad} not in allowed options {options}"
-            return None
-        if value not in options:
-            return f"value {value!r} not in allowed options {options}"
+        # Numeric Slider bounds (no options): reject out-of-range, like the UI.
+        props = entry.get("props") or {}
+        lo, hi = props.get("min"), props.get("max")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            if lo is not None and value < lo:
+                return f"value {value} is below the minimum {lo}"
+            if hi is not None and value > hi:
+                return f"value {value} is above the maximum {hi}"
         return None
     return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.4"
+version = "0.3.5"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/_slider_app.py
+++ b/tests/_slider_app.py
@@ -1,0 +1,20 @@
+"""Helper callback for the #120 Slider-bounds test.
+
+Deliberately has **no** ``from __future__ import annotations`` so the documented
+slider type hints resolve to real ``range`` / ``Annotated`` objects at
+inference time — i.e. the exact way a user's plain script (the issue's repro)
+builds the app. (Defining it inside the future-annotations ``test_mcp`` module
+would stringify the annotations and degrade the widget; that's the separate
+issue #119.)
+"""
+
+from typing import Annotated
+
+
+def slider_demo(
+    via_annot: Annotated[int, range(0, 100)] = 30,   # Annotated[int, range] -> Slider
+    via_range: int = range(0, 100),                  # int with range() default -> Slider
+    plain_num: int = 5,                              # int -> NumberInput (unbounded)
+) -> str:
+    """Echo the three numeric inputs."""
+    return f"{via_annot} {via_range} {plain_num}"

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+from typing import Annotated  # module-level so get_type_hints can resolve it (#119)
 
 import pandas as pd  # noqa: F401  (module-level for any -> pd.DataFrame hints)
 import plotly.graph_objects as go
@@ -367,14 +368,47 @@ class TestTools:
         assert items["options"] == ["apples", "pears", "figs"]
         # and no raw object repr leaks into the default contract field.
         assert items["default"] is None
+        # #119: now that future annotations no longer degrade inference, the dict
+        # builds a real MultiSelect (no value), so current_value is a clean None.
+        assert items["current_value"] is None
+
+    def test_future_annotations_do_not_degrade_inference(self):
+        # #119: this module uses `from __future__ import annotations`, so every
+        # annotation below reaches component inference as a *string* ("dict",
+        # "list", "Annotated[...]"). Inference must resolve them (get_type_hints)
+        # rather than fall through to a Text box — so a dict stays a MultiSelect,
+        # a list a Select, and Annotated[int, range] a bounded Slider. (This also
+        # restores the #120 slider contract under future annotations.)
+        def cfg(
+            items: dict = {"a": 1, "b": 2},
+            fruit: str = ["x", "y", "z"],
+            level: Annotated[int, range(0, 10)] = 3,
+            free: str = "hi",
+        ) -> str:
+            """Echo."""
+            return "ok"
+
+        app = FastDash(callback_fn=cfg, mcp_server=True)
+        c = _client_for(app)
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+
+        assert by_id["items"]["options"] == ["a", "b"]        # dict -> MultiSelect keys
+        assert by_id["items"]["current_value"] is None        # real widget, not a text box
+        assert by_id["fruit"]["options"] == ["x", "y", "z"]   # list -> Select dropdown
+        assert by_id["level"]["props"] == {"min": 0, "max": 10, "step": 1}  # Slider bounds
+        assert "props" not in by_id["free"]                   # plain str stays free text
+        assert by_id["free"]["options"] is None
+        # the resolved Slider's bounds are enforced too.
+        assert _call(c, "set_input", {"component_id": "level", "value": 99})["ok"] is False
 
     def test_slider_bounds_in_contract_and_range_validation(self):
         # #120: a static Slider must expose its min/max/step in the contract (so
         # an agent can discover the range), and set_input/invoke must reject
         # out-of-range values the UI slider can never produce (parity). The
-        # callback lives in a plain module (see tests/_slider_app.py) so the
-        # documented slider hints aren't stringified by this module's future
-        # annotations (that degradation is the separate issue #119).
+        # callback lives in a plain module (tests/_slider_app.py) — a faithful
+        # copy of the issue's plain-script repro. (Sliders defined inline here
+        # also work now that #119 resolves future annotations; the inline test
+        # above covers that path.)
         from tests._slider_app import slider_demo
         app = FastDash(callback_fn=slider_demo, mcp_server=True)
         c = _client_for(app)

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -368,6 +368,36 @@ class TestTools:
         # and no raw object repr leaks into the default contract field.
         assert items["default"] is None
 
+    def test_slider_bounds_in_contract_and_range_validation(self):
+        # #120: a static Slider must expose its min/max/step in the contract (so
+        # an agent can discover the range), and set_input/invoke must reject
+        # out-of-range values the UI slider can never produce (parity). The
+        # callback lives in a plain module (see tests/_slider_app.py) so the
+        # documented slider hints aren't stringified by this module's future
+        # annotations (that degradation is the separate issue #119).
+        from tests._slider_app import slider_demo
+        app = FastDash(callback_fn=slider_demo, mcp_server=True)
+        c = _client_for(app)
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+
+        # bounded sliders expose props; the plain number box does not.
+        assert by_id["via_annot"]["props"] == {"min": 0, "max": 100, "step": 1}
+        assert by_id["via_range"]["props"] == {"min": 0, "max": 100, "step": 1}
+        assert "props" not in by_id["plain_num"]          # genuinely unbounded
+
+        # out-of-range rejected; in-range accepted; unbounded input stays free.
+        hi = _call(c, "set_input", {"component_id": "via_annot", "value": 99999})
+        assert hi["ok"] is False and "maximum" in hi["error"]
+        lo = _call(c, "set_input", {"component_id": "via_annot", "value": -50})
+        assert lo["ok"] is False and "minimum" in lo["error"]
+        assert _call(c, "set_input", {"component_id": "via_annot", "value": 42})["ok"]
+        assert _call(c, "set_input", {"component_id": "plain_num", "value": 99999})["ok"]
+
+        # invoke stays atomic: an out-of-range value rejects without mutating.
+        out = _call(c, "invoke", {"inputs": {"via_annot": 99999}})
+        assert out["ok"] is False and out["errors"]["via_annot"]
+        assert app._mcp_state.inputs["via_annot"] == 42   # unchanged from set_input
+
     def test_set_input_and_invoke_validate_against_options(self):
         # #116 (note): a value the UI Select can never produce must be rejected,
         # mirroring the unknown-id guard (human<->agent parity). Valid values and


### PR DESCRIPTION
Release **0.3.5** — two routine-found fixes, shipped together.

- **#120 — `describe_app()` exposes a static Slider's `min`/`max`/`step`** and `set_input`/`invoke` reject out-of-range numerics (extends the 0.3.4 options validation). An agent can now discover and stay within a slider's range.
- **#119 — type-hint inference no longer degrades under `from __future__ import annotations`.** A `dict`/`list`/`Annotated[int, range(...)]` input no longer silently renders as a Text box; annotations are resolved (via `get_type_hints`, with a per-parameter fallback) before building components. This also restores #120's slider bounds under future annotations.

Tagging `v0.3.5` after merge publishes to PyPI + GitHub release + docs, and auto-closes #119 and #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
