### PR TITLE
Release 0.4.0 — UI/UX modernization + go.Figure render fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,39 @@
-# Release 0.3.5
+# Release 0.4.0
+
+## 0.4.0 (2026-06-30)
+
+A UI/UX modernization pass on the default app surface, plus a real
+figure-rendering fix.
+
+### Bug fixes
+- **A `plotly.graph_objects.Figure` return *type* now renders.** Output
+  inference mapped the string annotation `"go.Figure"` to a Graph but the actual
+  `go.Figure` *type* (any module without `from __future__ import annotations`)
+  fell through to an `html.H1`, so the figure dict was rendered as a React child
+  and crashed (React error #31), leaving the chart blank. Plotly figures — the
+  most common Fast Dash output — now render either way.
+
+### Changed
+- **Inputs are now rendered entirely with Mantine components.** Numeric inputs
+  use `dmc.NumberInput` and booleans use `dmc.Checkbox` (instead of the previous
+  `dbc` controls), so every control follows the app's theme and dark mode. This
+  fixes a number field staying white in dark mode and a checkbox rendering in an
+  off-theme accent color. (The boolean input's `component_property` is now
+  `checked` rather than `value`.)
+- **A `str` input is a single-line text field by default.** Only a multi-line or
+  long (>120 char) default becomes a text area, and a hex-color default
+  (e.g. `"#1c7ed6"`) becomes a color picker. Previously every `str` became a
+  tall text area, so forms scrolled before reaching the Run button.
+
+### Added
+- **Modern output cards.** Each output has a header strip (title + divider), a
+  soft shadow with a hover lift, and a "Run to see results" empty state.
+- **The Run button is pinned to the bottom of the input sidebar**, so it stays
+  visible regardless of how many inputs there are; the inputs scroll
+  independently above it.
+- **Overflow containment.** A large output (wide table, long text) scrolls
+  *inside* its card on both axes instead of growing out of its grid cell or
+  pushing a neighbor off-screen; input controls stay within the sidebar width.
 
 ## 0.3.5 (2026-06-29)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,9 @@ Inputs (parameter type → UI component):
 
 | Type hint | Component |
 | --- | --- |
-| `str` | Textarea |
+| `str` | Single-line text input |
+| `str` with a multi-line / long default | Text area |
+| `str` with a hex-color default (e.g. `"#1c7ed6"`) | Color picker |
 | `str` with `default=[...]` | Single-select dropdown |
 | `int`, `float` | Number input |
 | `int`/`float` with `range(...)` default | Slider |

--- a/docs/User guide/patterns.md
+++ b/docs/User guide/patterns.md
@@ -30,7 +30,8 @@ Here are some examples:
 | Input is | Type hint | Default value | Example   |
 |-----------|-----------|---------------|-----------|
 <b>Text<b>
-| Text | `str` | Any | `def my_func(arg1: str)`|
+| Text | `str` | Any (a multi-line / long default becomes a text area) | `def my_func(arg1: str)`|
+| Color | `str` | A hex color, e.g. `"#1c7ed6"` (renders a color picker) | `def style(color: str = "#1c7ed6")` |
 | Single item from a list of fixed items | `str` | List of allowed text items | `def get_gdp(country: str = ["USA", "Canada", "Mexico"])` |
 | List of items and users can add their own items | `list` | Blank | `def enter_web_urls(urls: list)` |
 | List of items and users must choose from a fixed set of items | `list` | List of fixed set of items | `def enter_web_urls(urls: list = ["google.com", "youtube.com", "facebook.com", "bing.com"])` |

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -477,19 +477,54 @@ class AppLayout:
                 )
             )
 
+        # Separate the trailing "Run" button row (appended by _make_input_groups)
+        # so it can be pinned to the bottom of the sidebar instead of scrolling
+        # off the bottom of a tall form.
+        inputs = list(self.inputs or [])
+        submit_row = None
+        if inputs and isinstance(inputs[-1], html.Div):
+            submit_row = inputs.pop()
+
         sidebar_children.append(
             dmc.Stack(
-                children=self.inputs,
+                children=inputs,
                 gap="lg",
                 id="input-group",
             )
         )
 
-        return dmc.ScrollArea(
-            dmc.Stack(sidebar_children, gap="md"),
-            style={"height": "100%"},
-            id="input-group-wrapper",
-        )
+        # Mantine's scrollable-navbar pattern: a `grow` section that *is* the
+        # scroll area holds the inputs, and the Run button lives in a fixed
+        # footer section so it stays pinned no matter how many inputs there are.
+        # (A position:sticky button inside dmc.ScrollArea does NOT stick — Radix
+        # wraps the content in a way that breaks sticky — so it scrolled away
+        # once the form was taller than the viewport.)
+        sections = [
+            dmc.AppShellSection(
+                dmc.ScrollArea(
+                    dmc.Stack(sidebar_children, gap="md"),
+                    type="auto",
+                    style={"height": "100%"},
+                    id="input-group-wrapper",
+                ),
+                grow=True,
+                style={"minHeight": 0, "overflow": "hidden"},
+            )
+        ]
+        if submit_row is not None:
+            sections.append(
+                dmc.AppShellSection(
+                    html.Div(
+                        submit_row,
+                        style={
+                            "paddingTop": "12px",
+                            "borderTop": "1px solid var(--mantine-color-default-border)",
+                        },
+                    )
+                )
+            )
+
+        return sections
 
     def generate_output_component(self):
         """Build the main content area with mosaic output grid."""
@@ -578,7 +613,13 @@ class AppLayout:
                     navbar_content,
                     p="md",
                     id="navbar3260780",
-                    style={"overflowY": "auto"},
+                    # Column so the grow inputs-section scrolls and the Run
+                    # footer section stays pinned; the section owns scrolling.
+                    style={
+                        "display": "flex",
+                        "flexDirection": "column",
+                        "overflow": "hidden",
+                    },
                 ),
                 dmc.AppShellMain(
                     html.Div(
@@ -799,6 +840,17 @@ def _get_readable_names_from_parent_classes(type_hint):
     return None
 
 
+def _is_hex_color(s):
+    """True for a ``#rgb`` / ``#rrggbb`` hex-color string (case-insensitive)."""
+    if not isinstance(s, str):
+        return False
+    s = s.strip()
+    if not s.startswith("#"):
+        return False
+    body = s[1:]
+    return len(body) in (3, 6) and all(c in "0123456789abcdefABCDEF" for c in body)
+
+
 def _get_component_from_input(hint, default_value=None):
     """
     Get FastComponent to represent the given input.
@@ -853,19 +905,27 @@ def _get_component_from_input(hint, default_value=None):
 
     if _hint_type == "Text":
         if _default_value_type == "Text":
-            component = Fastify(
-                dmc.Textarea(
-                    value=default_value,
-                    autosize=True,
-                    minRows=4,
-                ),
-                "value",
-                tag=_hint_type,
-            )
+            # A short single-line string is a single-line TextInput; a hex color
+            # is a swatch picker; only genuinely long / multi-line text gets a
+            # Textarea. (Previously every str became a tall Textarea.)
+            if _is_hex_color(default_value):
+                component = Fastify(
+                    dmc.ColorInput(value=default_value), "value", tag=_hint_type
+                )
+            elif "\n" in default_value or len(default_value) > 120:
+                component = Fastify(
+                    dmc.Textarea(value=default_value, autosize=True, minRows=3),
+                    "value",
+                    tag=_hint_type,
+                )
+            else:
+                component = Fastify(
+                    dmc.TextInput(value=default_value), "value", tag=_hint_type
+                )
 
         elif _default_value_type == "Numeric":
             component = Fastify(
-                dbc.Input(value=default_value, type="number"), "value", tag=_hint_type
+                dmc.NumberInput(value=default_value), "value", tag=_hint_type
             )
 
         elif _default_value_type == "Sequence":
@@ -875,22 +935,22 @@ def _get_component_from_input(hint, default_value=None):
 
         elif _default_value_type == "Dictionary":
             component = Fastify(
-                dbc.Input(value=str(default_value)), "value", tag=_hint_type
+                dmc.TextInput(value=str(default_value)), "value", tag=_hint_type
             )
 
         elif _default_value_type == "Boolean":
             component = Fastify(
-                dbc.Input(value=str(default_value)), "value", tag=_hint_type
+                dmc.TextInput(value=str(default_value)), "value", tag=_hint_type
             )
 
         elif _default_value_type == "Date":
             component = Fastify(
-                dbc.Input(value=str(default_value)), "value", tag=_hint_type
+                dmc.TextInput(value=str(default_value)), "value", tag=_hint_type
             )
 
         elif _default_value_type == "Timestamp":
             component = Fastify(
-                dbc.Input(value=str(default_value)), "value", tag=_hint_type
+                dmc.TextInput(value=str(default_value)), "value", tag=_hint_type
             )
 
         else:
@@ -900,14 +960,14 @@ def _get_component_from_input(hint, default_value=None):
     elif _hint_type == "Numeric":
         if _default_value_type == "Text":
             component = Fastify(
-                dbc.Input(value=hint(default_value), type="number"),
+                dmc.NumberInput(value=hint(default_value)),
                 "value",
                 tag=_hint_type,
             )
 
         elif _default_value_type == "Numeric":
             component = Fastify(
-                dbc.Input(value=default_value, type="number"), "value", tag=_hint_type
+                dmc.NumberInput(value=default_value), "value", tag=_hint_type
             )
 
         elif _default_value_type == "Sequence":
@@ -940,7 +1000,7 @@ def _get_component_from_input(hint, default_value=None):
             )
 
         else:
-            component = Fastify(dbc.Input(type="number"), "value", tag=_hint_type)
+            component = Fastify(dmc.NumberInput(), "value", tag=_hint_type)
 
     elif _hint_type == "Sequence":
         if _default_value_type == "Text":
@@ -989,13 +1049,15 @@ def _get_component_from_input(hint, default_value=None):
         )
 
     elif _hint_type == "Boolean":
+        # Mantine Checkbox follows the app's primary color and dark theme; the
+        # old dbc.Checkbox rendered with the Bootswatch accent (off-theme).
         if _default_value_type == "Boolean":
             component = Fastify(
-                dbc.Checkbox(value=default_value), "value", tag=_hint_type
+                dmc.Checkbox(checked=default_value), "checked", tag=_hint_type
             )
 
         else:
-            component = Fastify(dbc.Checkbox(), "value", tag=_hint_type)
+            component = Fastify(dmc.Checkbox(), "checked", tag=_hint_type)
 
     elif _hint_type == "Image":
         if _default_value_type == "Image":
@@ -1069,12 +1131,12 @@ def _get_component_from_input(hint, default_value=None):
         if _default_value_type is not None:
             if _default_value_type == "Text":
                 component = Fastify(
-                    dbc.Input(value=default_value), "value", tag=_default_value_type
+                    dmc.TextInput(value=default_value), "value", tag=_default_value_type
                 )
 
             elif _default_value_type == "Numeric":
                 component = Fastify(
-                    dbc.Input(value=default_value, type="number"),
+                    dmc.NumberInput(value=default_value),
                     "value",
                     tag=_default_value_type,
                 )
@@ -1114,7 +1176,7 @@ def _get_component_from_input(hint, default_value=None):
 
             elif _default_value_type == "Boolean":
                 component = Fastify(
-                    dbc.Checkbox(value=default_value), "value", tag=_default_value_type
+                    dmc.Checkbox(checked=default_value), "checked", tag=_default_value_type
                 )
 
             elif _default_value_type == "Date":
@@ -1227,6 +1289,17 @@ def _get_output_components(_hint_type):
 
         elif issubclass(_hint_type, pd.DataFrame):
             component = Table
+
+        elif issubclass(_hint_type, go.Figure):
+            # A real ``go.Figure`` *type* annotation (no ``from __future__ import
+            # annotations``) must map to a Graph whose ``figure`` prop receives
+            # the figure — otherwise the figure dict is rendered as a child and
+            # React throws (#31). The string path above handles the PEP-563 case.
+            component = Fastify(
+                dcc.Graph(style=dict(height="100%", width="100%")),
+                "figure",
+                tag="Graph",
+            )
 
         elif _hint_type == mpl.figure.Figure:
             component = Image

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.3.5"
+__version__ = "0.4.0"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/assets/fast_dash.css
+++ b/fast_dash/assets/fast_dash.css
@@ -1,0 +1,109 @@
+/* Fast Dash output cards — modern card treatment, overflow containment, and
+   empty state. Uses Mantine CSS variables so it adapts to light/dark. */
+
+.fd-output-card {
+  /* min-* 0 lets the card sit inside its grid cell without being forced wider
+     (or taller) by a big child — wide tables / long text scroll inside the
+     card instead of pushing it out of the allocated space. */
+  min-width: 0;
+  min-height: 0;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 1px 3px rgba(0, 0, 0, 0.06);
+  transition: box-shadow 160ms ease, transform 160ms ease, border-color 160ms ease;
+}
+
+.fd-output-card:hover {
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.06), 0 6px 16px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+
+/* Header strip: title + a hairline divider separating it from the body. */
+.fd-output-header {
+  flex: 0 0 auto;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--mantine-color-default-border);
+}
+
+/* Body is the scroll container: content larger than the cell scrolls here
+   (both axes) instead of growing the card. min-height/min-width 0 are required
+   so the flex child can shrink below its content size and actually scroll. */
+.fd-output-body {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  overflow: auto;
+  padding: 16px;
+}
+
+.fd-output-content {
+  position: relative;
+  z-index: 1;
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  width: 100%;
+}
+
+/* Centered hint shown before any output exists. It sits behind the content
+   (z-index 0); pointer-events:none keeps it from intercepting clicks. It is
+   hidden as soon as a real output renders (rules below) so it never shows
+   through transparent text/markdown. */
+.fd-output-placeholder {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mantine-color-dimmed);
+  pointer-events: none;
+  user-select: none;
+  z-index: 0;
+}
+
+.fd-output-placeholder-icon {
+  opacity: 0.35;
+}
+
+/* Hide the empty-state hint once any real output content has rendered, across
+   the Fast Dash output types (plot, table, image, markdown/text). */
+.fd-output-body:has(.fd-output-content .js-plotly-plot) .fd-output-placeholder,
+.fd-output-body:has(.fd-output-content .dash-table-container) .fd-output-placeholder,
+.fd-output-body:has(.fd-output-content table) .fd-output-placeholder,
+.fd-output-body:has(.fd-output-content img) .fd-output-placeholder,
+.fd-output-body:has(.fd-output-content p) .fd-output-placeholder,
+.fd-output-body:has(.fd-output-content li) .fd-output-placeholder,
+.fd-output-body:has(.fd-output-content pre) .fd-output-placeholder,
+.fd-output-body:has(.fd-output-content h1, .fd-output-content h2, .fd-output-content h3) .fd-output-placeholder {
+  display: none;
+}
+
+/* --- Input sidebar overflow containment -------------------------------------
+   Keep every control within the navbar width: the sidebar never scrolls
+   horizontally; a wide value / label / widget wraps or clips inside its own
+   box instead of pushing the sidebar (or the page) wider. Mirrors the output
+   card's min-width:0 containment. */
+#input-group-wrapper {
+  overflow-x: hidden;
+}
+
+.fd-input-group {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* Direct children (label, the input widget, the acknowledge slot) must not
+   exceed the column; min-width:0 lets a flex/grid widget shrink and scroll
+   internally rather than forcing the sidebar wider. */
+.fd-input-group > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
+/* A long, unbreakable label (e.g. a custom label_ with no spaces) wraps
+   instead of overflowing. Param-name labels already wrap on spaces. */
+.fd-input-label {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}

--- a/fast_dash/utils.py
+++ b/fast_dash/utils.py
@@ -559,11 +559,13 @@ def _make_input_groups(inputs_with_ids, update_live, prefix="", show_submit=True
         input_groups.append(
             dmc.Stack(
                 [
-                    dmc.Text(display_label, size="sm", fw=500),
+                    dmc.Text(display_label, size="sm", fw=500,
+                             className="fd-input-label"),
                     input_,
                     ack_component,
                 ],
                 gap=4,
+                className="fd-input-group",
             )
         )
 
@@ -620,16 +622,45 @@ def _make_output_groups(outputs, update_live, prefix=""):
         output_groups.append(
             dmc.Paper(
                 [
-                    dmc.Text(label, size="xs", fw=500, c="dimmed", mb=8),
+                    # Header strip with the output's title.
                     html.Div(
-                        output_,
-                        style={"width": "100%", "overflow": "hidden", "flex": "1"},
+                        dmc.Text(label, size="sm", fw=600),
+                        className="fd-output-header",
+                    ),
+                    # Body: the output, with an empty-state hint layered behind.
+                    html.Div(
+                        [
+                            html.Div(
+                                dmc.Stack(
+                                    [
+                                        DashIconify(
+                                            icon="ph:chart-line-duotone",
+                                            width=32,
+                                            className="fd-output-placeholder-icon",
+                                        ),
+                                        dmc.Text("Run to see results", size="sm"),
+                                    ],
+                                    align="center",
+                                    gap=6,
+                                ),
+                                className="fd-output-placeholder",
+                            ),
+                            html.Div(output_, className="fd-output-content"),
+                        ],
+                        className="fd-output-body",
                     ),
                 ],
-                p="md",
-                radius="sm",
+                p=0,
+                radius="md",
                 withBorder=True,
-                style={"width": "100%", "display": "flex", "flexDirection": "column", "flex": "1"},
+                className="fd-output-card",
+                style={
+                    "width": "100%",
+                    "display": "flex",
+                    "flexDirection": "column",
+                    "flex": "1",
+                    "overflow": "hidden",
+                },
             )
         )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.3.5"
+version = "0.4.0"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_fast_dash_autodetect.py
+++ b/tests/test_fast_dash_autodetect.py
@@ -69,8 +69,7 @@ def test_fdco002_hint_is_not_of_type_type(dash_duo):
     app = FastDash(callback_fn=simple_integer)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
-        and input_component.type == "number"
+        input_component.__doc__ == dmc.NumberInput().__doc__
     ), "Hint is integer failed"
 
 
@@ -118,7 +117,7 @@ def test_fdco004_input_hint_is_text(dash_duo):
     app = FastDash(callback_fn=simple_text)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == Text.__doc__
+        input_component.__doc__ == dmc.TextInput().__doc__
         and hasattr(input_component, "value")
         and input_component.value == "Default text"
     ), "Default text failed"
@@ -130,9 +129,7 @@ def test_fdco004_input_hint_is_text(dash_duo):
     app = FastDash(callback_fn=simple_text)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
-        and hasattr(input_component, "type")
-        and input_component.type == "number"
+        input_component.__doc__ == dmc.NumberInput().__doc__
         and hasattr(input_component, "value")
         and input_component.value == 2.2
     ), "Default number failed"
@@ -158,7 +155,7 @@ def test_fdco004_input_hint_is_text(dash_duo):
     app = FastDash(callback_fn=simple_text)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
+        input_component.__doc__ == dmc.TextInput().__doc__
         and not hasattr(input_component, "type")
         and hasattr(input_component, "value")
         and input_component.value
@@ -172,7 +169,7 @@ def test_fdco004_input_hint_is_text(dash_duo):
     app = FastDash(callback_fn=simple_text)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
+        input_component.__doc__ == dmc.TextInput().__doc__
         and not hasattr(input_component, "type")
         and hasattr(input_component, "value")
         and input_component.value == str(True)
@@ -185,7 +182,7 @@ def test_fdco004_input_hint_is_text(dash_duo):
     app = FastDash(callback_fn=simple_text)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
+        input_component.__doc__ == dmc.TextInput().__doc__
         and not hasattr(input_component, "type")
         and hasattr(input_component, "value")
         and input_component.value == str(datetime.date(2022, 8, 11))
@@ -198,7 +195,7 @@ def test_fdco004_input_hint_is_text(dash_duo):
     app = FastDash(callback_fn=simple_text)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
+        input_component.__doc__ == dmc.TextInput().__doc__
         and not hasattr(input_component, "type")
         and hasattr(input_component, "value")
         and input_component.value == str(datetime.datetime(2022, 8, 11, 12, 44, 56))
@@ -215,9 +212,7 @@ def test_fdco005_input_hint_is_numeric(dash_duo):
     app = FastDash(callback_fn=simple_num)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
-        and hasattr(input_component, "type")
-        and input_component.type == "number"
+        input_component.__doc__ == dmc.NumberInput().__doc__
         and hasattr(input_component, "value")
         and input_component.value == 2.2
     ), "Default text failed"
@@ -229,9 +224,7 @@ def test_fdco005_input_hint_is_numeric(dash_duo):
     app = FastDash(callback_fn=simple_num)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
-        and hasattr(input_component, "type")
-        and input_component.type == "number"
+        input_component.__doc__ == dmc.NumberInput().__doc__
         and hasattr(input_component, "value")
         and input_component.value == 2.2
     ), "Default number failed"
@@ -361,11 +354,11 @@ def test_fdco008_input_hint_is_boolean(dash_duo):
     app = FastDash(callback_fn=simple_bool)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Checkbox().__doc__
-        and hasattr(input_component, "value")
-        and input_component.value is True
+        input_component.__doc__ == dmc.Checkbox().__doc__
+        and hasattr(input_component, "checked")
+        and input_component.checked is True
         and hasattr(input_component, "component_property")
-        and input_component.component_property == "value"
+        and input_component.component_property == "checked"
     ), "Default = True failed"
 
     # No default value (False by default)
@@ -375,10 +368,10 @@ def test_fdco008_input_hint_is_boolean(dash_duo):
     app = FastDash(callback_fn=simple_bool)
     input_component = app.inputs_with_ids[0]
     assert (
-        input_component.__doc__ == dbc.Checkbox().__doc__
-        and not hasattr(input_component, "value")
+        input_component.__doc__ == dmc.Checkbox().__doc__
+        and not hasattr(input_component, "checked")
         and hasattr(input_component, "component_property")
-        and input_component.component_property == "value"
+        and input_component.component_property == "checked"
     ), "Default = False failed"
 
 
@@ -484,7 +477,7 @@ def test_fdco012_input_hint_is_unknown(dash_duo):
     input_component = app.inputs_with_ids[0]
 
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
+        input_component.__doc__ == dmc.TextInput().__doc__
         and not hasattr(input_component, "type")
         and hasattr(input_component, "value")
         and input_component.value == "Some text"
@@ -498,9 +491,7 @@ def test_fdco012_input_hint_is_unknown(dash_duo):
     input_component = app.inputs_with_ids[0]
 
     assert (
-        input_component.__doc__ == dbc.Input().__doc__
-        and hasattr(input_component, "type")
-        and input_component.type == "number"
+        input_component.__doc__ == dmc.NumberInput().__doc__
         and hasattr(input_component, "value")
         and input_component.value == 137.2736
     ), "Default number failed"
@@ -557,11 +548,11 @@ def test_fdco012_input_hint_is_unknown(dash_duo):
     input_component = app.inputs_with_ids[0]
 
     assert (
-        input_component.__doc__ == dbc.Checkbox().__doc__
+        input_component.__doc__ == dmc.Checkbox().__doc__
         and hasattr(input_component, "component_property")
-        and input_component.component_property == "value"
-        and hasattr(input_component, "value")
-        and input_component.value is True
+        and input_component.component_property == "checked"
+        and hasattr(input_component, "checked")
+        and input_component.checked is True
     ), "Default boolean failed"
 
     # 6. Default value is date
@@ -754,6 +745,25 @@ def test_fdco016_output_is_dash_component(dash_duo):
         and hasattr(output_component, "component_property")
         and output_component.component_property == "children"
     ), "Dash component failed"
+
+
+def test_figure_output_type_maps_to_graph(dash_duo):
+    "A real go.Figure return *type* must map to a Graph(figure=...), not H1 children."
+    import plotly.graph_objects as go
+
+    # This module has no `from __future__ import annotations`, so the annotation
+    # is the actual go.Figure type (the case that previously fell through to an
+    # html.H1 whose children received the figure dict -> React #31, blank chart).
+    def make_fig(n: int = 3) -> go.Figure:
+        return go.Figure(go.Scatter(y=list(range(n))))
+
+    app = FastDash(callback_fn=make_fig)
+    output_component = app.outputs[0]
+    assert (
+        output_component.__doc__ == dcc.Graph().__doc__
+        and hasattr(output_component, "component_property")
+        and output_component.component_property == "figure"
+    ), "go.Figure output type should map to a Graph with the figure property"
 
 
 def test_fdco017_output_is_chat(dash_duo):

--- a/tests/test_multi_function.py
+++ b/tests/test_multi_function.py
@@ -98,9 +98,9 @@ def test_multi_function_with_modern_hints():
     assert a_inputs[0].__doc__ == dmc.Select().__doc__, "Literal should be Select"
     assert a_inputs[1].__doc__ == dmc.Slider().__doc__, "Annotated range should be Slider"
 
-    # func_b should have Text input
+    # func_b should have a single-line text input
     b_inputs = app.func_data[1]["inputs_with_ids"]
-    assert b_inputs[0].__doc__ == Text.__doc__, "str should be Text"
+    assert b_inputs[0].__doc__ == dmc.TextInput().__doc__, "str should be a TextInput"
 
 
 def test_single_function_unchanged():
@@ -112,7 +112,7 @@ def test_single_function_unchanged():
     app = FastDash(func)
     assert app.is_multi is False
     assert not hasattr(app, "func_data") or not app.func_data if hasattr(app, "func_data") else True
-    assert app.inputs_with_ids[0].__doc__ == Text.__doc__
+    assert app.inputs_with_ids[0].__doc__ == dmc.TextInput().__doc__
     assert app.inputs_with_ids[0].id == "text"
 
 

--- a/tests/test_typing_hints.py
+++ b/tests/test_typing_hints.py
@@ -108,7 +108,7 @@ def test_optional_str_input():
 
     app = FastDash(callback_fn=func)
     comp = app.inputs_with_ids[0]
-    assert comp.__doc__ == Text.__doc__, "Optional[str] should resolve to Text"
+    assert comp.__doc__ == dmc.TextInput().__doc__, "Optional[str] should resolve to a TextInput"
     assert comp.value == "hello", "Optional[str] default value should be preserved"
 
 
@@ -120,8 +120,8 @@ def test_optional_int_input():
 
     app = FastDash(callback_fn=func)
     comp = app.inputs_with_ids[0]
-    assert comp.__doc__ == dbc.Input().__doc__, "Optional[int] should resolve to numeric input"
-    assert comp.type == "number", "Optional[int] should be number type"
+    assert comp.__doc__ == dmc.NumberInput().__doc__, "Optional[int] should resolve to a NumberInput"
+    assert comp.value == 5, "Optional[int] default should be preserved"
 
 
 def test_optional_output():
@@ -229,7 +229,7 @@ def test_plain_str_still_works():
 
     app = FastDash(callback_fn=func)
     comp = app.inputs_with_ids[0]
-    assert comp.__doc__ == Text.__doc__, "Plain str should still produce Text"
+    assert comp.__doc__ == dmc.TextInput().__doc__, "Plain str should produce a TextInput"
     assert comp.value == "hello", "Plain str default should be preserved"
 
 
@@ -241,8 +241,7 @@ def test_plain_int_still_works():
 
     app = FastDash(callback_fn=func)
     comp = app.inputs_with_ids[0]
-    assert comp.__doc__ == dbc.Input().__doc__, "Plain int should still produce numeric input"
-    assert comp.type == "number", "Plain int should be number type"
+    assert comp.__doc__ == dmc.NumberInput().__doc__, "Plain int should produce a NumberInput"
     assert comp.value == 5, "Plain int default should be preserved"
 
 
@@ -254,8 +253,8 @@ def test_plain_bool_still_works():
 
     app = FastDash(callback_fn=func)
     comp = app.inputs_with_ids[0]
-    assert comp.__doc__ == dbc.Checkbox().__doc__, "Plain bool should still produce Checkbox"
-    assert comp.value is True, "Plain bool default should be preserved"
+    assert comp.__doc__ == dmc.Checkbox().__doc__, "Plain bool should produce a Checkbox"
+    assert comp.checked is True, "Plain bool default should be preserved"
 
 
 def test_no_type_hint_still_works():
@@ -267,8 +266,8 @@ def test_no_type_hint_still_works():
     app = FastDash(callback_fn=func)
     comp = app.inputs_with_ids[0]
     # No hint with str default falls through to default-value inference,
-    # which produces a dbc.Input (not Text/Textarea)
-    assert comp.__doc__ == dbc.Input().__doc__, "No hint with str default should produce Input"
+    # which produces a single-line TextInput.
+    assert comp.__doc__ == dmc.TextInput().__doc__, "No hint with str default should produce a TextInput"
 
 
 ########### Combined / complex scenarios ###########
@@ -291,5 +290,5 @@ def test_mixed_modern_hints():
 
     assert app.inputs_with_ids[1].__doc__ == dmc.Slider().__doc__, "Second input should be Slider"
 
-    assert app.inputs_with_ids[2].__doc__ == Text.__doc__, "Third input should be Text"
+    assert app.inputs_with_ids[2].__doc__ == dmc.TextInput().__doc__, "Third input should be a TextInput"
     assert app.inputs_with_ids[2].value == "Hello", "Optional[str] default should be preserved"


### PR DESCRIPTION
Release **0.4.0** — UI/UX modernization of the default app surface, plus a real figure-rendering fix.

- **fix:** a `go.Figure` return *type* now renders (was a blank chart / React #31 without `from __future__ import annotations`).
- **changed:** inputs are fully Mantine (NumberInput/Checkbox), so they follow the theme + dark mode; `str` → single-line text input by default (multi-line/long → text area, hex → color picker).
- **added:** modern output cards (header, shadow, empty state); Run button pinned to the sidebar bottom (robust across input counts); overflow containment for both inputs and outputs.

Full CI matrix green on the source PR (#127): Py 3.11–3.14 × ubuntu/macos, including the selenium suite. CHANGELOG, README/docs type-hint reference, and version updated.

Tagging `v0.4.0` after merge publishes to PyPI + GitHub release + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
