### PR TITLE
fix: report Enum input defaults consistently in describe_app (#126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
-# Release 0.4.0
+# Release 0.4.1
+
+## 0.4.1 (2026-07-01)
+
+### Bug fixes
+- **`describe_app()` reports Enum input defaults consistently.** A plain
+  `enum.Enum` default was reported as `default: null` (even though a default
+  exists), and an `IntEnum`'s `default`/`options` were ints while its
+  `current_value` was a string — so the contract self-contradicted and an agent
+  building `invoke(...)` from the advertised default passed a different type than
+  a UI Run. The contract now reports `str(member.value)` for an Enum's `default`
+  and `options`, matching the value the UI `Select` emits (which fast_dash builds
+  with `str(e.value)`), so `default` / `options` / `current_value` are all
+  type-consistent. Same contract-correctness class as #110 / #116 / #120. (#126)
 
 ## 0.4.0 (2026-06-30)
 

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -249,7 +249,9 @@ def _annotation_options(annotation):
         if typing.get_origin(annotation) is typing.Literal:
             return list(typing.get_args(annotation))
         if isinstance(annotation, type) and issubclass(annotation, enum.Enum):
-            return [e.value for e in annotation]
+            # Match the UI Select, which is built with str(e.value) options — so
+            # an IntEnum's options are ["1", "2"], not [1, 2] (issue #126).
+            return [str(e.value) for e in annotation]
     except Exception:
         pass
     return None
@@ -306,6 +308,8 @@ def _describe_static_inputs(fd, snapshot):
     defaults into clean JSON and **never** leaks an object ``repr`` into a
     contract field (issue #116).
     """
+    import enum
+
     from fast_dash.utils import _jsonify_for_mcp, depends_on
 
     descriptors = _enumerate_inputs(fd)
@@ -343,6 +347,14 @@ def _describe_static_inputs(fd, snapshot):
                     # parent value, resolved exactly as the live cascade does.
                     if options is None:
                         options = _resolve_depends_on_options(fd, dflt, snapshot)
+                elif isinstance(dflt, enum.Enum):
+                    # An Enum member's contract value is str(member.value) — the
+                    # exact value the UI Select emits (Components builds it with
+                    # value=str(e.value)). Handle it before the scalar branch
+                    # below, since str-mixin / IntEnum members ARE str/int (which
+                    # would otherwise surface the raw int for an IntEnum, out of
+                    # sync with options and current_value). (issue #126)
+                    default = str(dflt.value)
                 elif isinstance(dflt, list):
                     if options is None:
                         options = list(dflt)          # list default = dropdown options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.4.0"
+version = "0.4.1"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -12,6 +12,7 @@ fixture enforces that here by resetting the registry before each test.
 
 from __future__ import annotations
 
+import enum
 import importlib.util
 import json
 from typing import Annotated  # module-level so get_type_hints can resolve it (#119)
@@ -22,6 +23,18 @@ import pytest
 
 from fast_dash import DynamicDash, FastDash, Graph, Markdown
 from fast_dash.mcp import MCPState, enable_mcp
+
+
+# Module-level so get_type_hints resolves them under this file's future
+# annotations (used by the #126 Enum-contract test).
+class Flavor(enum.Enum):
+    VANILLA = "vanilla"
+    CHOCO = "choco"
+
+
+class Qty(enum.IntEnum):
+    ONE = 1
+    TWO = 2
 
 _HAS_DASH_MCP = importlib.util.find_spec("dash.mcp") is not None
 requires_dash_mcp = pytest.mark.skipif(
@@ -453,6 +466,29 @@ class TestTools:
         out = _call(c, "invoke", {"inputs": {"flavor": "mango"}})
         assert out["ok"] is False and out["errors"]["flavor"]
         assert app._mcp_state.inputs["flavor"] == "choco"   # unchanged
+
+    def test_enum_defaults_are_type_consistent(self):
+        # #126: a plain Enum default was reported as null, and an IntEnum's
+        # default/options were ints while current_value was a string. Every field
+        # should be str(member.value) — the value the UI Select actually emits.
+        def order(flavor: Flavor = Flavor.CHOCO, qty: Qty = Qty.TWO) -> str:
+            """Place an order."""
+            return f"{qty} {flavor}"
+        app = FastDash(callback_fn=order, mcp_server=True)
+        c = _client_for(app)
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+
+        # plain Enum: default is the member's value (was null).
+        assert by_id["flavor"]["default"] == "choco"
+        assert by_id["flavor"]["options"] == ["vanilla", "choco"]
+        assert by_id["flavor"]["current_value"] == "choco"
+
+        # IntEnum: default / options / current_value are type-consistent strings,
+        # matching the Select (was default 2 / options [1, 2] vs current "2").
+        q = by_id["qty"]
+        assert q["default"] == "2"
+        assert q["options"] == ["1", "2"]
+        assert q["current_value"] == "2"
 
     def test_describe_app_reflects_dynamic_form(self):
         # #106: after set_form, describe_app must report the agent-built form's


### PR DESCRIPTION
Fixes #126 (filed by the nightly dogfood routine).

## The bug

`describe_app()` — the documented agent contract — mis-reported Enum input defaults:

| input | kind | `default` | `options` | `current_value` |
|---|---|---|---|---|
| plain `enum.Enum` | | **`null`** ❌ | `["vanilla","choco"]` | `"choco"` |
| `IntEnum` | | `2` (int) | `[1, 2]` (ints) | `"2"` (str) ❌ |

So the contract self-contradicted (`default: 2` vs `current_value: "2"`), and an agent building `invoke({"qty": 2})` from the advertised default passed an `int` while a UI Run passes the string `"2"`. Same contract-correctness class as #110/#116/#120.

## Fix

The UI `Select` is built with `str(e.value)` for both its options and value. Make the contract match:
- `_describe_static_inputs`: handle `enum.Enum` defaults explicitly (before the scalar branch, since `IntEnum`/`str`-mixin members *are* int/str) using `str(member.value)`.
- `_annotation_options`: return `str(e.value)` for Enum members.

Now `default` / `options` / `current_value` are all `str` and consistent with the Select and the equivalent `Literal` path (verified against the issue's repro).

Regression test added. Bumps `0.4.0 → 0.4.1`. MCP + inference suites green (79 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
