### PR TITLE
fix(mcp): describe_app contract consistency + date defaults (0.5.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ The agent calls **`describe_app()`** to discover the input contract (each input'
 
 ```python
 # From the agent's side, in one call:
-invoke({"n": 12, "color": "#2f9e44"})   # set inputs and run, one round-trip
+invoke(inputs={"n": 12, "color": "#2f9e44"})   # set inputs and run, one round-trip
 ```
 
 **Agent-generated UI** with `DynamicDash` — the form materializes when an agent calls the `set_form` tool:

--- a/docs/User guide/ai_agents.md
+++ b/docs/User guide/ai_agents.md
@@ -76,7 +76,7 @@ defaults, allowed options, and **current values** — and use that to build a va
 
 ```python
 # From the agent's side — set inputs and run in a single round-trip:
-invoke({"n": 12, "color": "#2f9e44"})
+invoke(inputs={"n": 12, "color": "#2f9e44"})
 ```
 
 Agent mutations are reflected in the **live browser** within ~500 ms (no
@@ -107,7 +107,7 @@ app.run(port=8052)                    # run() mounts the MCP server on :8052/mcp
 The agent then calls, for example:
 
 ```python
-set_form([
+set_form(specs=[
     {"name": "communication", "type": "Slider", "props": {"min": 0, "max": 10}},
     {"name": "technical",     "type": "Slider", "props": {"min": 0, "max": 10}},
 ])

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,33 @@
 # History
 
+# Release 0.5.1
+
+## 0.5.1 (2026-07-04)
+
+### Bug fixes
+- **`describe_app()` reports a JSON `type` consistently across app kinds.** A
+  static app derived each input's `type` from the callback annotation (a JSON
+  type like `"integer"`), but a `DynamicDash` form reported the *component name*
+  (`"Slider"`) in the same field — so a headless agent reading `type` got two
+  different vocabularies. `DynamicDash` now reports the JSON type too, with the
+  component name always in `tag` (as on a static app). (#131)
+- **`Optional[T]` inputs report `T`'s type, not `"string"`.** An
+  `Optional[int]` / `int | None` parameter collapsed to `type: "string"` because
+  the raw `Union` wrapper isn't in the type map. The wrapper is now unwrapped to
+  its single non-`None` member, so an optional input advertises the type it
+  actually accepts (`integer` / `number` / `boolean`). (#132)
+- **Date/datetime input defaults are surfaced, not dropped.** A `DateInput` /
+  timestamp built from a `datetime.date` / `datetime.datetime` default reported
+  `default: null` (the default-handling branch didn't match a date object). It
+  now surfaces the ISO string the DatePicker emits, keeping the time component
+  for a `datetime`. (#134)
+- **Docs: MCP tool examples use keyword arguments.** The flagship `invoke` /
+  `set_form` snippets in the README and the AI-agents guide showed
+  `invoke({...})` / `set_form([...])`, omitting the required `inputs=` / `specs=`
+  keyword the tools expect. (#137)
+
+Same contract-correctness class as #110 / #116 / #120 / #126.
+
 # Release 0.5.0
 
 ## 0.5.0 (2026-07-03)

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -234,11 +234,50 @@ def _seed_input_mirror(fd) -> None:
 
 
 def _json_type_name(annotation) -> str:
-    """Best-effort JSON-schema type name for a Python annotation."""
+    """Best-effort JSON-schema type name for a Python annotation.
+
+    Unwraps ``Optional[T]`` / ``Union[T, None]`` (and PEP 604 ``T | None``) to
+    the single non-``None`` member first, so an optional parameter reports the
+    type it actually accepts instead of collapsing to ``"string"`` (issue #132).
+    """
+    try:
+        import types as _types
+        import typing
+
+        origin = typing.get_origin(annotation)
+        is_union = origin is typing.Union or (
+            hasattr(_types, "UnionType") and origin is _types.UnionType
+        )
+        if is_union:
+            members = [a for a in typing.get_args(annotation) if a is not type(None)]
+            if len(members) == 1:
+                annotation = members[0]
+    except Exception:
+        pass
     return {
         int: "integer", float: "number", str: "string",
         bool: "boolean", list: "array", dict: "object",
     }.get(annotation, "string")
+
+
+# JSON type each DynamicDash spec component emits. Lets describe_app report a
+# uniform JSON ``type`` for both static and dynamic apps — a static app derived
+# it from the callback annotation, a DynamicDash form has no annotations, so it
+# derives it from the spec's component name here. The component name itself
+# always stays in the ``tag`` field. (issue #131)
+_SPEC_JSON_TYPE = {
+    "Text": "string", "TextArea": "string", "Select": "string",
+    "DateInput": "string", "ColorInput": "string", "PasswordInput": "string",
+    "Markdown": "string", "Upload": "string", "UploadImage": "string",
+    "NumberInput": "number", "Slider": "number",
+    "Switch": "boolean",
+    "MultiSelect": "array", "DateRange": "array",
+}
+
+
+def _spec_json_type(spec_type) -> str:
+    """JSON type for a DynamicDash spec component name, defaulting to string."""
+    return _SPEC_JSON_TYPE.get(spec_type, "string")
 
 
 def _annotation_options(annotation):
@@ -361,6 +400,12 @@ def _describe_static_inputs(fd, snapshot):
                 elif isinstance(dflt, dict):
                     if options is None:
                         options = list(dflt.keys())   # dict default = MultiSelect keys
+                elif isinstance(dflt, (datetime.date, datetime.datetime)):
+                    # A DateInput/date-range default is a date/datetime object, not
+                    # a scalar — surface its ISO string (the exact value the browser
+                    # DatePicker emits) instead of dropping it to null. isoformat()
+                    # keeps the time component for a datetime. (issue #134)
+                    default = dflt.isoformat()
                 elif isinstance(dflt, (str, bool, int, float)):
                     default = dflt                    # a scalar default IS the value
                 # else (range / arbitrary objects): leave default None so the
@@ -809,8 +854,11 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
                 cur = snapshot.get(name, default)
                 inputs.append({
                     "id": name,
+                    # tag = the DynamicDash component name (e.g. "Slider");
+                    # type = its JSON type, so ``type`` means the same thing here
+                    # as on a static app's contract (issue #131).
                     "tag": spec.get("type"),
-                    "type": spec.get("type"),
+                    "type": _spec_json_type(spec.get("type")),
                     "label": spec.get("label"),
                     "default": _jsonify_for_mcp(default),
                     "options": _jsonify_for_mcp(options),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.5.0"
+version = "0.5.1"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -12,10 +12,11 @@ fixture enforces that here by resetting the registry before each test.
 
 from __future__ import annotations
 
+import datetime  # module-level so get_type_hints resolves date/datetime hints (#134)
 import enum
 import importlib.util
 import json
-from typing import Annotated  # module-level so get_type_hints can resolve it (#119)
+from typing import Annotated, Optional  # module-level for get_type_hints (#119, #132)
 
 import pandas as pd  # noqa: F401  (module-level for any -> pd.DataFrame hints)
 import plotly.graph_objects as go
@@ -494,6 +495,51 @@ class TestTools:
         assert q["options"] == ["1", "2"]
         assert q["current_value"] == "2"
 
+    def test_optional_annotation_reports_wrapped_type(self):
+        # #132: an Optional[T] parameter reported type "string" because the raw
+        # Union wrapper isn't in the type map. The wrapper must be unwrapped to
+        # its single non-None member so the contract reports the type the input
+        # actually accepts (integer/number/boolean), not a blanket string.
+        def f(
+            count: Optional[int] = 3,
+            ratio: Optional[float] = None,
+            flag: Optional[bool] = True,
+            name: Optional[str] = "x",
+        ) -> str:
+            """Echo."""
+            return "ok"
+
+        app = FastDash(callback_fn=f, mcp_server=True)
+        c = _client_for(app)
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert by_id["count"]["type"] == "integer"   # was "string" pre-fix
+        assert by_id["ratio"]["type"] == "number"
+        assert by_id["flag"]["type"] == "boolean"
+        assert by_id["name"]["type"] == "string"
+        # a None default still surfaces as null (nothing to seed).
+        assert by_id["ratio"]["default"] is None
+        assert by_id["count"]["default"] == 3
+
+    def test_datetime_default_surfaces_iso_string(self):
+        # #134: a Date/Timestamp input built from a datetime.date / datetime
+        # default reported default null (the scalar branch didn't match a date
+        # object). It must surface the ISO string the DatePicker emits, keeping
+        # the time component for a datetime.
+        def sched(
+            day: datetime.date = datetime.date(2021, 6, 15),
+            at: datetime.datetime = datetime.datetime(2021, 6, 15, 10, 30),
+        ) -> str:
+            """Echo."""
+            return "ok"
+
+        app = FastDash(callback_fn=sched, mcp_server=True)
+        c = _client_for(app)
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert by_id["day"]["default"] == "2021-06-15"          # was null pre-fix
+        assert by_id["at"]["default"] == "2021-06-15T10:30:00"  # keeps the time
+        # dates travel as JSON strings (no native JSON date type).
+        assert by_id["day"]["type"] == "string"
+
     def test_describe_app_reflects_dynamic_form(self):
         # #106: after set_form, describe_app must report the agent-built form's
         # contract (id/type/props), not just the value mirror.
@@ -505,7 +551,10 @@ class TestTools:
         ]})
         by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
         assert set(by_id) == {"communication", "technical"}   # both discoverable
-        assert by_id["communication"]["type"] == "Slider"
+        # #131: type is a JSON type (as on a static app), the component name is
+        # in tag — so a headless agent reads ``type`` the same way everywhere.
+        assert by_id["communication"]["tag"] == "Slider"
+        assert by_id["communication"]["type"] == "number"
         assert by_id["communication"]["props"]["max"] == 10   # bounds exposed
         # set one field — both still listed; current_value updated for the set one.
         _call(c, "set_inputs", {"inputs": {"communication": 5}})


### PR DESCRIPTION
## Fast Dash 0.5.1 — describe_app contract fixes

A small patch fixing three `describe_app` contract-accuracy bugs (same class as #110 / #116 / #120 / #126), all surfaced by the nightly dogfood run, plus a docs fix. **312 non-browser tests green** (2 new regression tests).

### Bug fixes
- **#131** — `describe_app()` reported the DynamicDash component name (`"Slider"`) in the `type` field, while a static app reported a JSON type (`"integer"`). A headless agent read `type` two different ways. DynamicDash now reports a JSON `type` too, with the component name kept in `tag` (matching a static app). New `_spec_json_type` map.
- **#132** — an `Optional[int]` / `int | None` parameter collapsed to `type: "string"` (the raw `Union` wrapper isn't in the type map). `_json_type_name` now unwraps `Optional`/`Union` to its single non-`None` member first, so an optional input advertises the type it actually accepts.
- **#134** — a Date/Timestamp input built from a `datetime.date` / `datetime.datetime` default reported `default: null`. It now surfaces the ISO string the DatePicker emits, keeping the time component for a `datetime`.
- **#137** (docs) — the flagship `invoke()` / `set_form()` snippets in the README and the AI-agents guide omitted the required `inputs=` / `specs=` keyword the tools expect.

### Changes
- `fast_dash/mcp.py` — `_json_type_name` (Optional unwrap), `_spec_json_type` (new), datetime default branch, DynamicDash `type` field.
- `tests/test_mcp.py` — regression tests for #131/#132/#134.
- `docs/history.md` — 0.5.1 entry; `pyproject.toml` + `__init__.py` bumped to 0.5.1.
- `README.md`, `docs/User guide/ai_agents.md` — keyword-arg fix.

Closes #131, #132, #134, #137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)