### PR TITLE
fix(chat): sidecar run_app renders outputs, not just inputs (0.5.2)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,21 @@
 # History
 
+# Release 0.5.2
+
+## 0.5.2 (2026-07-05)
+
+### Bug fixes
+- **Chat sidecar `run_app` now renders the outputs, not just the inputs.** When a
+  `chat_agent` drove the app (`set_input` + `run_app`), it correctly updated the
+  input controls and computed the new outputs — but the outputs stayed hidden
+  behind the pre-run "Run to see results" placeholder, so the charts never
+  refreshed until the user clicked Run manually. The placeholder
+  (`fd-not-run` on `#output-group-col`) was only cleared by a real Run
+  (`submit_inputs.n_clicks`), which the sidecar never fires. The drive path now
+  clears it on a `run_app` (both the Flask drive reducer and the ASGI
+  `set_props` path), so an agent's run refreshes the *view* — the "anything you
+  can do, the agent can do" promise holds for outputs too.
+
 # Release 0.5.1
 
 ## 0.5.1 (2026-07-04)

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.5.1"
+__version__ = "0.5.2"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/chat_app.py
+++ b/fast_dash/chat_app.py
@@ -370,10 +370,18 @@ class ChatAppMixin:
                       for inp in self.inputs_with_ids]
         out_outputs = [Output(out.id, out.component_property, allow_duplicate=True)
                        for out in self.outputs_with_ids]
-        outputs = in_outputs + out_outputs
-        if not outputs:
+        value_outputs = in_outputs + out_outputs
+        if not value_outputs:
             return
         n_in, n_out = len(in_outputs), len(out_outputs)
+        # On a run_app, also clear the pre-run 'fd-not-run' placeholder so the
+        # agent's run refreshes the *view*, not just the inputs. The placeholder
+        # is otherwise only cleared by a manual Run (submit_inputs.n_clicks),
+        # which the sidecar never fires -- so outputs were written but stayed
+        # hidden behind "Run to see results".
+        drive_outputs = value_outputs + [
+            Output("output-group-col", "className", allow_duplicate=True)
+        ]
         app.clientside_callback(
             """
             function(payload) {
@@ -382,15 +390,17 @@ class ChatAppMixin:
                 var i;
                 if (!payload || payload.op !== 'drive') {
                     for (i = 0; i < %d; i++) { res.push(no); }
+                    res.push(no);
                     return res;
                 }
                 var inv = payload.inputs, ov = payload.outputs;
                 for (i = 0; i < %d; i++) { res.push(inv ? inv[i] : no); }
                 for (i = 0; i < %d; i++) { res.push(ov ? ov[i] : no); }
+                res.push(payload.ran ? '' : no);   // reveal outputs on a run
                 return res;
             }
             """ % (n_in + n_out, n_in, n_out),
-            outputs,
+            drive_outputs,
             Input("socketio", "data-chat_drive"),
             prevent_initial_call=True,
         )
@@ -1145,6 +1155,11 @@ class ChatAppMixin:
                 if outputs is not None:
                     for out, val in zip(self.outputs_with_ids, outputs):
                         set_props(out.id, {out.component_property: val})
+                if ran:
+                    # Clear the pre-run placeholder so the run reveals the outputs
+                    # (parity with the Flask reducer; otherwise only a manual Run
+                    # clears it). See _register_chat_drive_reducer.
+                    set_props("output-group-col", {"className": ""})
                 # Flash affordance: bump a tick store so a clientside callback
                 # highlights the just-changed controls / pulses the output.
                 self._drive_tick += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.5.1"
+version = "0.5.2"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1183,6 +1183,26 @@ class TestChatSidecar:
         # data-chat_drive prop can't clobber the set_inputs made this turn.
         assert drive[2]["inputs"] == [10, 20]
 
+    def test_run_app_clears_pre_run_placeholder_flask(self):
+        # A sidecar run_app writes the outputs, but the "Run to see results"
+        # placeholder (fd-not-run on #output-group-col) is otherwise only cleared
+        # by a manual Run (submit_inputs.n_clicks) -- so the agent's run left the
+        # outputs written-but-hidden. The Flask drive reducer must also clear the
+        # placeholder from the same chat_drive op.
+        def dashboard(a: int = 1) -> str:
+            return str(a)
+        def agent(query, ctx):
+            yield {"type": "run_app"}
+        app = FastDash(callback_fn=dashboard, chat_agent=agent)
+        wired = False
+        for out_key, spec in app.app.callback_map.items():
+            if "output-group-col.className" not in out_key:
+                continue
+            inputs = [f"{i['id']}.{i['property']}" for i in spec.get("inputs", [])]
+            if any("data-chat_drive" in x for x in inputs):
+                wired = True
+        assert wired, "drive reducer must clear output-group-col on a run"
+
     def test_drive_on_asgi_uses_set_props(self):
         import dash
         def dashboard(a: int = 1, b: int = 2) -> str:
@@ -1200,6 +1220,10 @@ class TestChatSidecar:
         assert ("a", {"value": 7}) in non_transcript
         # The single output component was updated with sum=9.
         assert any(list(p.values()) == ["sum=9"] for _, p in non_transcript)
+        # ...and the pre-run "Run to see results" placeholder is cleared, so the
+        # run reveals the outputs instead of leaving them hidden (issue: sidecar
+        # run_app drove inputs but never rendered the view).
+        assert ("output-group-col", {"className": ""}) in non_transcript
 
     def test_sidecar_on_multi_is_conversational_and_guards_drive(self):
         def f1(x: int = 1) -> str: return f"f1={x}"


### PR DESCRIPTION
## Fast Dash 0.5.2 — sidecar `run_app` renders the view

A `chat_agent` sidecar driving the app (`set_input` + `run_app`) correctly updated the input controls and computed new outputs — but the **outputs stayed hidden** behind the pre-run "Run to see results" placeholder, so the charts never refreshed until the user clicked Run manually. This broke the sidecar's core promise ("anything you can do, the agent can do") for outputs.

### Root cause
The placeholder is `fd-not-run` on `#output-group-col` (CSS hides `.fd-output-content`). It's cleared only by a clientside callback keyed on `submit_inputs.n_clicks` — i.e. a manual Run. The sidecar's `run_app` pushes new output *values* into the components but never fires `n_clicks`, so the values were written **behind** a hidden overlay.

### Fix
Clear the placeholder from the drive path on a `run_app`, in both transports:
- **Flask**: the drive reducer (`_register_chat_drive_reducer`) adds `output-group-col.className` to its outputs and returns `''` when `payload.ran`.
- **ASGI**: `_emit_drive` calls `set_props("output-group-col", {"className": ""})` when `ran`.

### Verification
- New Flask wiring test + extended ASGI drive test; **313 non-browser tests green**.
- Verified live in a browser: a copilot ("Switch to California and forecast 3 days ahead") now drives the inputs **and** the charts render automatically — no manual Run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)