### PR TITLE
feat(chat): mode-aware, customizable empty-transcript placeholder (0.5.3)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,18 @@
 # History
 
+# Release 0.5.3
+
+## 0.5.3 (2026-07-05)
+
+### Changed
+- **The empty-chat hint fits the app and the mode.** The transcript's
+  placeholder was hardcoded to "Ask the assistant to change the output." — which
+  reads oddly for a pure `chat=True` app (there is no output to change). It now
+  defaults per mode (a conversation for `chat=True`, "change the output" for a
+  canvas / sidecar) and is overridable with a new `chat_placeholder=` argument.
+  The text is rendered from a `data-placeholder` attribute so it can differ per
+  app.
+
 # Release 0.5.2
 
 ## 0.5.2 (2026-07-05)

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -788,13 +788,15 @@ class AppLayout:
 
         return layout
 
-    @staticmethod
-    def _chat_message_list():
+    def _chat_message_list(self):
         """The transcript container — shared by chat mode and the sidecar aside.
 
         Newest message at the visual bottom (column-reverse pins the scroll to
-        the bottom, as the Chat output component does).
+        the bottom, as the Chat output component does). The empty-transcript hint
+        is rendered by CSS from ``data-placeholder`` (set from the app's
+        ``chat_placeholder``) so it can differ per app and per mode.
         """
+        placeholder = getattr(self.app, "chat_placeholder", None) or ""
         return html.Div(
             [],
             id="chat-messages",
@@ -809,6 +811,7 @@ class AppLayout:
                 "gap": "14px",
                 "padding": "18px 8px",
             },
+            **{"data-placeholder": placeholder},
         )
 
     @staticmethod

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/assets/fast_dash.css
+++ b/fast_dash/assets/fast_dash.css
@@ -382,9 +382,10 @@
   border-top: 1px solid var(--mantine-color-default-border);
 }
 
-/* App-first (chat_drawer): empty chat hint. */
+/* Empty-transcript hint. Text comes from the chat list's data-placeholder
+   (set from FastDash(chat_placeholder=...)), so it fits the app and mode. */
 .fd-chat-list:empty::before {
-  content: "Ask the assistant to change the output.";
+  content: attr(data-placeholder);
   margin: auto;
   padding: 0 24px;
   color: var(--mantine-color-dimmed);

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -140,6 +140,7 @@ class FastDash(ChatAppMixin):
         chat_agent=None,
         chat_agent_title=None,
         chat_agent_drive=True,
+        chat_placeholder=None,
         mcp_server=False,
         mcp_port=8001,
         mcp_host="127.0.0.1",
@@ -342,6 +343,16 @@ class FastDash(ChatAppMixin):
         # chat_agent_drive=False makes the sidecar read-only: the agent can read
         # ctx.inputs and converse, but set_input / run_app are refused.
         self.chat_agent_drive = bool(chat_agent_drive)
+
+        # Empty-transcript hint. Defaults to the surface the assistant acts on:
+        # canvas/sidecar drive an *output*, so "change the output" fits; a pure
+        # chat is a conversation, so it shouldn't say that. Overridable.
+        if chat_placeholder is not None:
+            self.chat_placeholder = chat_placeholder
+        elif self.is_canvas or self.is_chat_drawer or self.has_chat_sidecar:
+            self.chat_placeholder = "Ask the assistant to change the output."
+        else:
+            self.chat_placeholder = "Send a message to start the conversation."
 
         self.mode = mode
         self.disable_logs = disable_logs
@@ -2138,6 +2149,7 @@ def fastdash(
     chat_agent=None,
     chat_agent_title=None,
     chat_agent_drive=True,
+    chat_placeholder=None,
     mcp_server=False,
     mcp_port=8001,
     mcp_host="127.0.0.1",
@@ -2261,6 +2273,7 @@ def fastdash(
             chat_agent=chat_agent,
             chat_agent_title=chat_agent_title,
             chat_agent_drive=chat_agent_drive,
+            chat_placeholder=chat_placeholder,
             mcp_server=mcp_server,
             mcp_port=mcp_port,
             mcp_host=mcp_host,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.5.2"
+version = "0.5.3"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1124,6 +1124,33 @@ class TestChatSidecar:
         assert {"chat-messages", "chat-input", "chat-send", "chat-aside",
                 "chat-sidecar-toggle", "chat-sidecar-close"} <= ids
 
+    def test_chat_placeholder_default_and_override(self):
+        # The empty-transcript hint (CSS reads data-placeholder) fits the mode:
+        # a pure chat is a conversation, a sidecar drives the output. Overridable.
+        def _placeholder(app):
+            found = []
+            def walk(c):
+                if getattr(c, "id", None) == "chat-messages":
+                    found.append(c)
+                ch = getattr(c, "children", None)
+                for x in (ch if isinstance(ch, (list, tuple)) else [ch]) if ch is not None else []:
+                    if hasattr(x, "children") or hasattr(x, "id"):
+                        walk(x)
+            walk(app.app.layout)
+            return found[0].to_plotly_json()["props"].get("data-placeholder")
+
+        pure = FastDash(callback_fn=lambda query: query, chat=True)
+        assert _placeholder(pure) == "Send a message to start the conversation."
+
+        def dfn(a: int = 1) -> str:
+            return str(a)
+        side = FastDash(callback_fn=dfn, chat_agent=lambda query, ctx: (yield "hi"))
+        assert _placeholder(side) == "Ask the assistant to change the output."
+
+        custom = FastDash(callback_fn=lambda query: query, chat=True,
+                          chat_placeholder="Add a source, then ask.")
+        assert _placeholder(custom) == "Add a source, then ask."
+
     def test_plain_app_has_no_chat_dom(self):
         app = FastDash(callback_fn=lambda x: "hi")
         ids = _layout_ids(app.app.layout)


### PR DESCRIPTION
## Fast Dash 0.5.3 — the empty-chat hint fits the app

The transcript placeholder was hardcoded to *"Ask the assistant to change the output."* — which reads oddly for a pure `chat=True` app (there's no output to change; it's a conversation).

### Change
- Defaults per mode: **`chat=True`** → *"Send a message to start the conversation."*; **canvas / sidecar** → *"Ask the assistant to change the output."* (unchanged there).
- New **`chat_placeholder=`** argument to override.
- Rendered from a `data-placeholder` attribute (CSS `content: attr(data-placeholder)`), so it can differ per app.

**314 non-browser tests green** (new placeholder test covers default + sidecar + override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)