### PR TITLE
feat(chat): chat_agent_position="sidebar" — chat inside the inputs sidebar (0.5.4)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,17 @@
 # History
 
+# Release 0.5.4
+
+## 0.5.4 (2026-07-05)
+
+### Added
+- **`chat_agent_position="sidebar"`** places the chat sidecar *inside the left
+  inputs sidebar* — stacked under the inputs, always visible — instead of the
+  default floating right aside (`"aside"`). The inputs take their natural height
+  and the chat fills the rest; the navbar is widened to give it (and its charts)
+  room. Good for putting a conversational assistant right next to the controls
+  it complements.
+
 # Release 0.5.3
 
 ## 0.5.3 (2026-07-05)

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -547,16 +547,24 @@ class AppLayout:
         # (A position:sticky button inside dmc.ScrollArea does NOT stick — Radix
         # wraps the content in a way that breaks sticky — so it scrolled away
         # once the form was taller than the viewport.)
+        # In sidebar mode the chat panel lives under the inputs, so the inputs
+        # take their natural (capped) height and the chat gets the growing space;
+        # otherwise the inputs own the scroll and Run is pinned at the bottom.
+        for_sidebar = (
+            getattr(self.app, "has_chat_sidecar", False)
+            and getattr(self.app, "chat_agent_position", "aside") == "sidebar"
+        )
         sections = [
             dmc.AppShellSection(
                 dmc.ScrollArea(
                     dmc.Stack(sidebar_children, gap="md"),
                     type="auto",
-                    style={"height": "100%"},
+                    style={"maxHeight": "38vh"} if for_sidebar else {"height": "100%"},
                     id="input-group-wrapper",
                 ),
-                grow=True,
-                style={"minHeight": 0, "overflow": "hidden"},
+                grow=not for_sidebar,
+                style=({"flex": "0 0 auto"} if for_sidebar
+                       else {"minHeight": 0, "overflow": "hidden"}),
             )
         ]
         if submit_row is not None:
@@ -569,6 +577,14 @@ class AppLayout:
                             "borderTop": "1px solid var(--mantine-color-default-border)",
                         },
                     )
+                )
+            )
+        if for_sidebar:
+            sections.append(
+                dmc.AppShellSection(
+                    self._chat_sidebar_panel(),
+                    grow=True,
+                    style={"minHeight": 0, "overflow": "hidden"},
                 )
             )
 
@@ -687,6 +703,30 @@ class AppLayout:
             id="chat-aside",
         )
 
+    def _chat_sidebar_panel(self):
+        """The sidecar chat as a panel stacked under the inputs in the navbar.
+
+        Used when ``chat_agent_position="sidebar"``: the same transcript +
+        composer as the aside, but always visible in the left sidebar below the
+        inputs (no floating toggle, no right aside).
+        """
+        title = getattr(self.app, "chat_agent_title", "Assistant")
+        header = html.Div(
+            dmc.Group(
+                [DashIconify(icon="tabler:message-2", width=18),
+                 html.Span(title, style={"fontWeight": 600})],
+                gap="xs", wrap="nowrap",
+            ),
+            style={"flex": "0 0 auto", "padding": "10px 2px 8px",
+                   "borderTop": "1px solid var(--mantine-color-default-border)"},
+        )
+        return html.Div(
+            [header, self._chat_message_list(), self._chat_composer()],
+            className="fd-chat-main",
+            style={"flex": "1 1 auto", "minHeight": 0, "height": "100%",
+                   "display": "flex", "flexDirection": "column"},
+        )
+
     def _chat_sidecar_toggle_button(self):
         """Floating button that opens/closes the chat sidecar aside."""
         title = getattr(self.app, "chat_agent_title", "Assistant")
@@ -709,6 +749,11 @@ class AppLayout:
         main_content = self.generate_output_component()
 
         has_sidecar = getattr(self.app, "has_chat_sidecar", False)
+        # Sidebar-positioned sidecar: the chat is stacked under the inputs in the
+        # navbar (built by generate_input_component), so there's no right aside
+        # and no floating toggle; the navbar is widened to give the chat room.
+        sidebar_chat = has_sidecar and (
+            getattr(self.app, "chat_agent_position", "aside") == "sidebar")
 
         appshell_children = [
             dmc.AppShellHeader(
@@ -740,11 +785,16 @@ class AppLayout:
         ]
         appshell_kwargs = dict(
             header={"height": 56},
-            navbar={"width": 300, "breakpoint": "sm", "collapsed": {"mobile": False}},
+            navbar={"width": 420 if sidebar_chat else 300, "breakpoint": "sm",
+                    "collapsed": {"mobile": False}},
             padding=0,
             id="appshell",
         )
-        if has_sidecar:
+        if sidebar_chat:
+            # The chat needs a wider sidebar than the default; a CSS var override
+            # (via this class) applies it reliably across dmc versions.
+            appshell_kwargs["className"] = "fd-chat-sidebar"
+        if has_sidecar and not sidebar_chat:
             appshell_children.append(self._chat_aside())
             # Collapsed by default; the floating toggle opens it. Full-width
             # sheet on small screens, fixed panel on desktop.
@@ -777,7 +827,8 @@ class AppLayout:
             # the clientside flash callback.
             extra.append(dcc.Store(id="chat-drive-tick"))
             extra.append(dcc.Store(id="chat-drive-flash"))
-            extra.append(self._chat_sidecar_toggle_button())
+            if not sidebar_chat:   # sidebar chat is always shown; no floating toggle
+                extra.append(self._chat_sidecar_toggle_button())
 
         layout = dmc.MantineProvider(
             [appshell] + extra,

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/assets/fast_dash.css
+++ b/fast_dash/assets/fast_dash.css
@@ -382,6 +382,12 @@
   border-top: 1px solid var(--mantine-color-default-border);
 }
 
+/* chat_agent_position="sidebar": widen the navbar so the stacked chat (and its
+   charts) have room. Overrides Mantine's inline --app-shell-navbar-width. */
+.fd-chat-sidebar {
+  --app-shell-navbar-width: 26.25rem !important;   /* 420px */
+}
+
 /* Empty-transcript hint. Text comes from the chat list's data-placeholder
    (set from FastDash(chat_placeholder=...)), so it fits the app and mode. */
 .fd-chat-list:empty::before {

--- a/fast_dash/chat_app.py
+++ b/fast_dash/chat_app.py
@@ -202,7 +202,8 @@ class ChatAppMixin:
 
         self._drive_tick = 0                          # bumped per drive (ASGI flash)
         self._register_chat_callbacks(register_chrome=False)
-        self._register_chat_sidecar_toggle()
+        if getattr(self, "chat_agent_position", "aside") != "sidebar":
+            self._register_chat_sidecar_toggle()      # no toggle when always shown
         self._register_chat_drive_reducer()
         self._register_chat_drive_flash()
 

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -140,6 +140,7 @@ class FastDash(ChatAppMixin):
         chat_agent=None,
         chat_agent_title=None,
         chat_agent_drive=True,
+        chat_agent_position="aside",
         chat_placeholder=None,
         mcp_server=False,
         mcp_port=8001,
@@ -343,6 +344,10 @@ class FastDash(ChatAppMixin):
         # chat_agent_drive=False makes the sidecar read-only: the agent can read
         # ctx.inputs and converse, but set_input / run_app are refused.
         self.chat_agent_drive = bool(chat_agent_drive)
+        # Where the sidecar chat lives: "aside" (a toggled right panel, default)
+        # or "sidebar" (stacked under the inputs in the left navbar, always shown).
+        _pos = str(chat_agent_position or "aside").lower()
+        self.chat_agent_position = _pos if _pos in ("aside", "sidebar") else "aside"
 
         # Empty-transcript hint. Defaults to the surface the assistant acts on:
         # canvas/sidecar drive an *output*, so "change the output" fits; a pure
@@ -2149,6 +2154,7 @@ def fastdash(
     chat_agent=None,
     chat_agent_title=None,
     chat_agent_drive=True,
+    chat_agent_position="aside",
     chat_placeholder=None,
     mcp_server=False,
     mcp_port=8001,
@@ -2273,6 +2279,7 @@ def fastdash(
             chat_agent=chat_agent,
             chat_agent_title=chat_agent_title,
             chat_agent_drive=chat_agent_drive,
+            chat_agent_position=chat_agent_position,
             chat_placeholder=chat_placeholder,
             mcp_server=mcp_server,
             mcp_port=mcp_port,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.5.3"
+version = "0.5.4"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -255,6 +255,20 @@ def _layout_ids(comp, out=None):
     return out
 
 
+def _find_by_id(comp, target):
+    """Return the first component in the tree whose id == target, else None."""
+    if getattr(comp, "id", None) == target:
+        return comp
+    ch = getattr(comp, "children", None)
+    if ch is not None:
+        for c in (ch if isinstance(ch, (list, tuple)) else [ch]):
+            if c is not None:
+                found = _find_by_id(c, target)
+                if found is not None:
+                    return found
+    return None
+
+
 class TestChatConstruction:
     """The D1 interaction matrix (RFC #133), enforced at construction time."""
 
@@ -1150,6 +1164,29 @@ class TestChatSidecar:
         custom = FastDash(callback_fn=lambda query: query, chat=True,
                           chat_placeholder="Add a source, then ask.")
         assert _placeholder(custom) == "Add a source, then ask."
+
+    def test_chat_agent_position_sidebar_stacks_chat_in_navbar(self):
+        # chat_agent_position="sidebar" moves the chat under the inputs in the
+        # left navbar: no right aside, no floating toggle.
+        def dashboard(a: int = 1) -> str:
+            return str(a)
+        app = FastDash(callback_fn=dashboard,
+                       chat_agent=lambda query, ctx: (yield "hi"),
+                       chat_agent_position="sidebar")
+        assert app.chat_agent_position == "sidebar"
+        ids = _layout_ids(app.app.layout)
+        assert {"chat-messages", "chat-input", "chat-send"} <= ids   # chat exists
+        assert "chat-aside" not in ids                               # ...not as an aside
+        assert "chat-sidecar-toggle" not in ids                      # ...and no float toggle
+        # the transcript is actually inside the navbar container
+        navbar = _find_by_id(app.app.layout, "navbar3260780")
+        assert "chat-messages" in _layout_ids(navbar)
+
+    def test_chat_agent_position_defaults_to_aside(self):
+        app = FastDash(callback_fn=lambda a=1: str(a),
+                       chat_agent=lambda query, ctx: (yield "x"))
+        assert app.chat_agent_position == "aside"
+        assert {"chat-aside", "chat-sidecar-toggle"} <= _layout_ids(app.app.layout)
 
     def test_plain_app_has_no_chat_dom(self):
         app = FastDash(callback_fn=lambda x: "hi")


### PR DESCRIPTION
## Fast Dash 0.5.4 — put the chat sidecar in the inputs sidebar

New **`chat_agent_position`** argument: `"aside"` (default, the floating right panel) or **`"sidebar"`** — the chat stacked *under the inputs* in the left navbar, always visible.

In `"sidebar"` mode: no right aside, no floating toggle; the inputs take their natural (capped) height and the chat fills the rest of the navbar, which is widened (via a CSS `--app-shell-navbar-width` override) so the chat and its charts have room. Great for a conversational assistant that belongs next to the controls it complements.

**316 non-browser tests green** (2 new: sidebar layout + aside default); verified in a browser (navbar 420px, chat + composer under the inputs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)