### PR TITLE
fix(chat): correct sidebar-chat navbar width so output and collapse align (0.5.5)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,21 @@
 # History
 
+# Release 0.5.5
+
+## 0.5.5 (2026-07-05)
+
+### Fixed
+- **`chat_agent_position="sidebar"` layout.** The wider (420px) sidebar wasn't
+  reaching Mantine's AppShell: the `toggle_sidebar` callback reset the navbar to
+  `width: 300` on load, so the main content offset and the collapse animation
+  were computed from the wrong width. The result was the output area sliding
+  *under* the sidebar (right panel clipped off-screen) and the sidebar refusing
+  to fully close (a ~120px strip stayed visible). The callback now returns the
+  sidebar-chat width, matching the layout, so the offset and collapse-transform
+  are consistent — the output fills the space beside the sidebar, and toggling
+  the inputs closes it completely. Removed the `--app-shell-navbar-width` CSS
+  override that was papering over the mismatch.
+
 # Release 0.5.4
 
 ## 0.5.4 (2026-07-05)

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -1130,8 +1130,16 @@ class AppLayout:
             else:
                 collapsed = {"desktop": False, "mobile": False}
 
+            # Sidebar-positioned chat stacks under the inputs and needs the wider
+            # navbar. Must match generate_layout's width, or dmc derives the main
+            # offset and collapse-transform from the wrong width -- leaving the
+            # output shifted under the sidebar and the sidebar unable to fully
+            # close. (Same reason canvas/drawer return their own widths above.)
+            sidebar_chat = getattr(self.app, "has_chat_sidecar", False) and (
+                getattr(self.app, "chat_agent_position", "aside") == "sidebar")
+
             return {
-                "width": 300,
+                "width": 420 if sidebar_chat else 300,
                 "breakpoint": "sm",
                 "collapsed": collapsed,
             }

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/assets/fast_dash.css
+++ b/fast_dash/assets/fast_dash.css
@@ -382,11 +382,12 @@
   border-top: 1px solid var(--mantine-color-default-border);
 }
 
-/* chat_agent_position="sidebar": widen the navbar so the stacked chat (and its
-   charts) have room. Overrides Mantine's inline --app-shell-navbar-width. */
-.fd-chat-sidebar {
-  --app-shell-navbar-width: 26.25rem !important;   /* 420px */
-}
+/* chat_agent_position="sidebar" widens the navbar (to 420px) via the AppShell
+   `navbar.width` prop in generate_layout + the toggle_sidebar callback, so
+   Mantine derives the main offset and collapse-transform from the real width.
+   No CSS var override here -- forcing only the width var desynced the offset
+   (output slid under the sidebar) and the collapse distance (sidebar wouldn't
+   fully close). The `.fd-chat-sidebar` class is kept as a styling hook. */
 
 /* Empty-transcript hint. Text comes from the chat list's data-placeholder
    (set from FastDash(chat_placeholder=...)), so it fits the app and mode. */

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.5.4"
+version = "0.5.5"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."


### PR DESCRIPTION
`chat_agent_position="sidebar"` widens the navbar to 420px, but the `toggle_sidebar` callback reset `appshell.navbar` to `width: 300` on load. Mantine then derived the main-content offset and the collapse-transform from 300px while the navbar rendered at 420px — a 120px mismatch that caused two visible bugs:

- **Output slid under the sidebar** — the right output panel was clipped off the screen edge.
- **Sidebar wouldn't fully close** — toggling the inputs left a ~120px strip visible over the output.

## Fix
Return the sidebar-chat width (420) from the callback too — matching `generate_layout` and mirroring the existing canvas(460)/drawer(320) branches — so dmc derives the offset and collapse-transform from the *real* width. Removed the now-unnecessary `--app-shell-navbar-width` CSS override that papered over the mismatch.

## Verification (in-browser)
- **Open:** `offset == navbar width == 420px` → output fills the space beside the sidebar, nothing clipped.
- **Collapsed:** `transform: -420px`, navbar fully off-screen, main padding `0` → output reclaims full width.
- Full test suite green (117 chat tests + full suite exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)