### PR TITLE
feat: typed agent events by default — langstage extractors + chat renderers (0.6.1)

### DIFF
--- a/docs/User guide/chat.md
+++ b/docs/User guide/chat.md
@@ -129,6 +129,41 @@ from fast_dash import FastDash
 FastDash(callback_fn="my_pkg.agents:graph", chat=True).run()
 ```
 
+## Typed agent events
+
+A LangGraph agent's tool results are rendered as **typed cards** automatically.
+When the agent calls a common tool, Fast Dash extracts a structured object from
+the result and shows a purpose-built card instead of a raw tool blob: a
+`think_tool` reflection collapses into a thinking block, `write_todos` becomes a
+task list with status icons, and `display_inline` renders figures, tables, and
+markdown inline. This is on by default (no configuration) for any LangGraph chat
+agent; the seven built-ins cover `think_tool`, `write_todos`, `memory`,
+`skill_view`, `skill_manage`, context compression, and `display_inline`.
+
+```python
+import json
+from langchain_core.tools import tool
+
+@tool
+def write_todos(todos: list) -> str:
+    """Track the plan; renders as a task list with status icons."""
+    return json.dumps(todos)   # [{"content": "...", "status": "completed"}, ...]
+
+@tool
+def display_inline(display_type: str, data) -> str:
+    """Render rich content inline (markdown / table / figure)."""
+    return json.dumps({"display_type": "markdown", "data": "# Result\nDone."})
+
+# Bind these tools to your LangGraph agent; FastDash(callback_fn=graph, chat=True)
+# renders each write_todos call as a task list and each display_inline call inline.
+```
+
+To handle a tool the built-ins don't know, pass `chat_extractors=` -- an iterable
+of objects with a `tool_name`, an `extracted_type`, and an `extract(content)`
+method. They are appended to the defaults (an extractor whose `tool_name` matches
+a built-in overrides it). A plain `(query, ctx)` chat callable ignores
+`chat_extractors=`.
+
 ## The `ctx` object
 
 `query` and `history` are all the 5-line chatbot needs. Power features fold into

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,50 @@
 # History
 
+# Release 0.6.1
+
+## 0.6.1 (2026-07-07)
+
+LangGraph chat agents now render their **typed agent events** as first-class
+cards by default. When an agent calls a common tool, Fast Dash's langstage
+bridge extracts a structured object from the tool result and shows a purpose-built
+card in the transcript instead of a raw tool blob -- a reflection collapses into a
+thinking block, a `write_todos` result becomes a task list with status icons, and
+`display_inline` renders figures / tables / markdown inline.
+
+### Added
+
+- **Typed agent-event rendering, on by default.** The langstage bridge now passes
+  the seven built-in extractors to `iter_event_frames`, so a LangGraph agent's
+  tool results stream as `extraction` frames that render as typed cards. No opt-in
+  is required; a plain `(query, ctx)` chat callable is unaffected.
+
+  | Tool | `extracted_type` | Rendered as |
+  |---|---|---|
+  | `think_tool` | `reflection` | a collapsible "Reflection" thinking block |
+  | `write_todos` | `todos` | a task list; per-item status icon, completed struck through |
+  | `memory` | `memory_updated` | a compact "Memory updated" callout |
+  | `skill_view` | `skill_loaded` | a "Skill loaded" callout |
+  | `skill_manage` | `skill_event` | a skill create / update / delete callout |
+  | `__compression__` | `compression_summary` | a subtle "Context compressed" divider callout |
+  | `display_inline` | `display_inline` | the flagship: figures / tables / markdown rendered inline (the same renderer artifacts use) |
+
+  An unknown `extracted_type` falls back to a compact collapsible JSON card, so a
+  typed event is never dropped.
+
+- **`chat_extractors=`** (new `FastDash` / `fastdash` parameter): an iterable of
+  extractor objects (each with a `tool_name`, an `extracted_type`, and a callable
+  `extract(content)`) appended to the built-in defaults, deduped by `tool_name`
+  with your extractor winning on a collision -- so you can override how any
+  built-in tool renders. Entries are duck-type validated at construction with a
+  friendly ASCII error. Only used for a LangGraph agent; a plain chat callable
+  ignores it silently.
+
+### Fixed
+
+- Inline artifact tables render as a real `DataTable` again (a `className` kwarg
+  unsupported by `dash_table.DataTable` on dash 4.3 had been silently falling back
+  to markdown text); the class now rides a wrapper div.
+
 # Release 0.6.0
 
 ## 0.6.0 (2026-07-07)

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/adapters/langstage.py
+++ b/fast_dash/adapters/langstage.py
@@ -21,6 +21,65 @@ _MISSING_EXTRA_MSG = (
 )
 
 
+def default_extractors():
+    """Fresh instances of the built-in langstage typed-object extractors.
+
+    These turn a LangGraph agent's tool results into ``extraction`` frames
+    (``think_tool`` -> reflection, ``write_todos`` -> todos, ``display_inline``
+    -> inline rich content, and the skill / memory / compression events) so the
+    chat renderer can show a typed card per event instead of a raw tool blob.
+
+    Imported lazily and extra-guarded: on a build without ``langstage-core`` the
+    list is empty, so a plain ``(query, ctx)`` chat callback is unaffected.
+    Returns fresh instances every call (extractors are cheap and stateless, and
+    the caller may dedupe/merge with user extractors).
+    """
+    try:
+        from langstage_core import (
+            CompressionExtractor,
+            DisplayInlineExtractor,
+            MemoryExtractor,
+            SkillManageExtractor,
+            SkillViewExtractor,
+            ThinkToolExtractor,
+            TodoExtractor,
+        )
+    except ImportError:                                # extra not installed
+        return []
+    return [
+        ThinkToolExtractor(),
+        TodoExtractor(),
+        MemoryExtractor(),
+        SkillViewExtractor(),
+        SkillManageExtractor(),
+        CompressionExtractor(),
+        DisplayInlineExtractor(),
+    ]
+
+
+def _merge_extractors(user_extractors):
+    """Built-in defaults plus ``user_extractors``, deduped by ``tool_name``.
+
+    A user extractor whose ``tool_name`` matches a built-in one wins (its entry
+    replaces the default), so an app can override the rendering of any built-in
+    tool while keeping the rest of the defaults. Order is preserved (defaults
+    first, then any user extractors for new tool names).
+    """
+    by_tool = {}
+    order = []
+    for ex in default_extractors():
+        name = getattr(ex, "tool_name", None)
+        if name not in by_tool:
+            order.append(name)
+        by_tool[name] = ex
+    for ex in (user_extractors or []):
+        name = getattr(ex, "tool_name", None)
+        if name not in by_tool:
+            order.append(name)
+        by_tool[name] = ex                             # user wins on collision
+    return [by_tool[name] for name in order]
+
+
 def is_langstage_target(obj) -> bool:
     """True if ``obj`` should be driven by the LangGraph adapter.
 
@@ -41,7 +100,7 @@ def is_langstage_target(obj) -> bool:
     return hasattr(obj, "get_graph") and hasattr(obj, "astream")
 
 
-def build_chat_callback(target):
+def build_chat_callback(target, extractors=None):
     """Return a chat callback ``(query, ctx)`` that streams ``target``.
 
     ``target`` is a compiled LangGraph graph or a spec string. The returned
@@ -49,6 +108,14 @@ def build_chat_callback(target):
     chat session id, injected by the turn runner) selects the checkpointer thread
     so sequential turns on one session share memory, and ``ctx.resume`` continues
     a turn paused on an interrupt (HITL).
+
+    ``extractors`` controls the typed-object streaming that turns tool results
+    into ``extraction`` frames (rendered as typed cards):
+
+    * ``None`` (default) -> the seven built-in extractors (see
+      :func:`default_extractors`).
+    * an iterable -> the built-ins **plus** those extractors, deduped by
+      ``tool_name`` with the user's extractor winning on a collision.
     """
     try:
         from langstage_core import load_agent_spec
@@ -58,17 +125,52 @@ def build_chat_callback(target):
 
     graph = load_agent_spec(target) if isinstance(target, str) else target
     agent = build_agent(graph)
+    merged = _merge_extractors(extractors)
 
     def _langstage_chat(query, ctx):
         """Stream a LangGraph agent turn as chat frames (via langstage-core)."""
         # iter_event_frames yields an async generator; the chat turn runner
         # drives sync and async generators uniformly.
         return iter_event_frames(agent, query, thread_id=ctx.thread_id or "default",
-                                 resume=ctx.resume)
+                                 resume=ctx.resume, extractors=merged)
 
     _langstage_chat.__fast_dash_langstage__ = True
     _langstage_chat.__fast_dash_agent__ = agent
     return _langstage_chat
+
+
+def validate_extractors(extractors):
+    """Return a list of ``extractors`` after duck-type validation (ASCII errors).
+
+    Each entry must satisfy the ``ToolExtractor`` protocol: a ``tool_name`` and
+    ``extracted_type`` (str-ish attributes) plus a callable ``extract``. This is
+    a construction-time check so a bad ``chat_extractors=`` fails with a friendly
+    message rather than deep inside a streaming turn. ``None`` -> ``[]``.
+    """
+    if extractors is None:
+        return []
+    try:
+        items = list(extractors)
+    except TypeError:
+        raise TypeError(
+            "chat_extractors must be an iterable of extractor objects "
+            "(each with tool_name, extracted_type, and extract). Got %r."
+            % (type(extractors).__name__,)
+        )
+    for i, ex in enumerate(items):
+        missing = [
+            attr for attr in ("tool_name", "extracted_type", "extract")
+            if not hasattr(ex, attr)
+        ]
+        if missing or not callable(getattr(ex, "extract", None)):
+            raise TypeError(
+                "chat_extractors[%d] is not a valid extractor: a %s is missing "
+                "%s. An extractor needs a 'tool_name' string, an "
+                "'extracted_type' string, and a callable 'extract(content)'."
+                % (i, type(ex).__name__,
+                   ", ".join(missing or ["a callable extract"]))
+            )
+    return items
 
 
 def make_resume_input(decisions, value=None):

--- a/fast_dash/assets/fast_dash.css
+++ b/fast_dash/assets/fast_dash.css
@@ -359,6 +359,28 @@
   color: var(--mantine-color-dimmed);
 }
 
+/* Typed agent events (langstage extraction frames, 0.6.1). */
+.fd-chat-extraction { margin-top: 6px; background: var(--mantine-color-body); }
+.fd-chat-extraction-title { font-weight: 600; font-size: 13px; }
+.fd-chat-extraction-summary { font-size: 13px; color: var(--mantine-color-dimmed); }
+.fd-chat-extraction-detail { font-size: 12px; color: var(--mantine-color-dimmed); }
+.fd-chat-extraction-status {
+  color: var(--mantine-color-dimmed); font-size: 13px; font-style: italic;
+  margin-top: 4px;
+}
+/* Task list (write_todos). */
+.fd-chat-todos { }
+.fd-chat-todo-row { margin-top: 4px; }
+.fd-chat-todo-text { font-size: 13px; }
+.fd-chat-todo-done { text-decoration: line-through; color: var(--mantine-color-dimmed); }
+/* Compact callouts (memory / skill). */
+.fd-chat-callout { background: var(--mantine-color-body); }
+/* Context-compression divider callout. */
+.fd-chat-compression { background: transparent; }
+.fd-chat-compression-divider { margin-bottom: 6px; }
+/* Inline rich content (display_inline). */
+.fd-chat-display-inline { }
+
 /* Developer-declared settings (model, temperature, upload) — static, on the
    chat side, above the composer. */
 .fd-chat-settings {

--- a/fast_dash/chat.py
+++ b/fast_dash/chat.py
@@ -20,6 +20,7 @@ Frame types:
     tool_start {"type": "tool_start","name": str, "args": dict|str, "id"?: str}
     tool_end   {"type": "tool_end",  "name": str, "result": Any,   "id"?: str}
     artifact   {"type": "artifact",  "content": Figure|DataFrame|Image|str}
+    extraction {"type": "extraction","tool_name": str, "extracted_type": str, "data": Any}
     interrupt  {"type": "interrupt", "action_requests": [...], "allowed_decisions": [...]}
     set_input  {"type": "set_input", "name": str, "value": Any}     (sidecar drive)
     run_app    {"type": "run_app"}                                   (sidecar drive)
@@ -71,6 +72,7 @@ REASONING = "reasoning"
 TOOL_START = "tool_start"
 TOOL_END = "tool_end"
 ARTIFACT = "artifact"
+EXTRACTION = "extraction"  # langstage typed-object event (todos/reflection/...)
 INTERRUPT = "interrupt"
 CANVAS = "canvas"          # rebuild the output canvas from a UI-spec list
 SET_PROPS = "set_props"    # patch one canvas component's props/value
@@ -87,7 +89,7 @@ ERROR = "error"
 # (canvas_tool_specs / apply_tool_call) still build these frame dicts for code
 # that opts into the canvas explicitly.
 _KNOWN_FRAME_TYPES = frozenset(
-    {CONTENT, REASONING, TOOL_START, TOOL_END, ARTIFACT,
+    {CONTENT, REASONING, TOOL_START, TOOL_END, ARTIFACT, EXTRACTION,
      INTERRUPT, SET_INPUT, RUN_APP, SET_OUTPUT, SET_LAYOUT, COMPLETE, ERROR}
 )
 
@@ -161,6 +163,19 @@ def _normalize_frame(frame):
         # Keep the raw payload on the object for server-side rendering; it is
         # replaced by a placeholder before hitting the wire (see wire_safe).
         frame = {"type": ARTIFACT, "content": frame["content"]}
+    elif ftype == EXTRACTION:
+        # A langstage typed-object event: {tool_name, extracted_type, data}.
+        # Both string keys are required; data is coerced JSON-safe so nothing a
+        # custom extractor returns can crash the socket (RFC principle 7).
+        if "extracted_type" not in frame:
+            raise ChatFrameError(
+                "An 'extraction' frame must have an 'extracted_type' key.")
+        frame = {
+            "type": EXTRACTION,
+            "tool_name": str(frame.get("tool_name", "")),
+            "extracted_type": str(frame["extracted_type"]),
+            "data": _json_safe_data(frame.get("data")),
+        }
     elif ftype == INTERRUPT:
         frame = {
             "type": INTERRUPT,
@@ -197,6 +212,22 @@ def _normalize_frame(frame):
 def _as_text(value):
     """Coerce a content payload to text without leaking a non-ASCII repr."""
     return value if isinstance(value, str) else str(value)
+
+
+def _json_safe_data(value):
+    """Return a JSON-serializable form of an extraction payload.
+
+    Extraction ``data`` crosses the socket raw (unlike an artifact, it is plain
+    structured data, not a live figure). The built-in extractors already return
+    JSON (lists / dicts / strings); this guards a *custom* extractor that returns
+    something exotic so a typed event never crashes the transport.
+    """
+    import json as _json
+    try:
+        _json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        return _json.loads(_json.dumps(value, default=str))
 
 
 def wire_safe(frame):

--- a/fast_dash/chat_app.py
+++ b/fast_dash/chat_app.py
@@ -127,7 +127,7 @@ class ChatAppMixin:
         agent = self._chat_agent
         # A LangGraph graph / "module:attr" spec is bridged to the frame grammar.
         if is_langstage_target(agent):
-            agent = build_chat_callback(agent)
+            agent = build_chat_callback(agent, getattr(self, "chat_extractors", None))
             self.is_langstage = True
 
         _params = list(inspect.signature(agent).parameters)
@@ -794,6 +794,8 @@ class ChatAppMixin:
                 parts.append(self._chat_tool_card(b))
             elif kind == "artifact":
                 parts.append(self._chat_artifact_block(b["content"], streaming))
+            elif kind == "extraction":
+                parts.append(self._chat_extraction_block(b, streaming))
             elif kind == "interrupt":
                 parts.append(self._chat_interrupt_card(b, pending=not b.get("resolved")))
         return html.Div(
@@ -856,12 +858,16 @@ class ChatAppMixin:
                          className="fd-chat-interrupt")
 
     @staticmethod
-    def _chat_reasoning_block(text):
-        """A collapsible 'thinking' block (native details/summary, no callback)."""
+    def _chat_reasoning_block(text, summary="Thinking"):
+        """A collapsible 'thinking' block (native details/summary, no callback).
+
+        ``summary`` labels the closed block; a langstage ``reflection`` event
+        reuses this renderer with a "Reflection" label.
+        """
         from dash import dcc, html
         return html.Details(
             [
-                html.Summary("Thinking", className="fd-chat-reasoning-summary"),
+                html.Summary(summary, className="fd-chat-reasoning-summary"),
                 dcc.Markdown(text or "", className="fd-chat-reasoning-body"),
             ],
             className="fd-chat-reasoning",
@@ -930,11 +936,15 @@ class ChatAppMixin:
             import pandas as pd
             if isinstance(content, pd.DataFrame):
                 from dash import dash_table
-                return dash_table.DataTable(
-                    data=content.to_dict("records"),
-                    columns=[{"name": str(c), "id": str(c)} for c in content.columns],
-                    page_size=10, sort_action="native",
-                    style_table={"overflowX": "auto"},
+                # Note: dash_table.DataTable does not accept className (dash 4.3),
+                # so the class rides a wrapper Div instead.
+                return html.Div(
+                    dash_table.DataTable(
+                        data=content.to_dict("records"),
+                        columns=[{"name": str(c), "id": str(c)} for c in content.columns],
+                        page_size=10, sort_action="native",
+                        style_table={"overflowX": "auto"},
+                    ),
                     className="fd-chat-artifact",
                 )
         except Exception:
@@ -957,6 +967,280 @@ class ChatAppMixin:
             pass
         # Fallback: render as markdown text.
         return dcc.Markdown(str(content), className="fd-chat-text")
+
+    # ----- typed langstage events (extraction frames) -------------------- #
+
+    def _chat_extraction_block(self, block, streaming=False):
+        """Render one langstage typed-object event by its ``extracted_type``.
+
+        Dispatches on ``extracted_type`` to a per-type Mantine card (todos,
+        reflection, memory / skill / compression callouts, display_inline rich
+        content). An unknown type falls back to a compact JSON card, so a typed
+        event is NEVER dropped. During streaming a lightweight one-line status
+        stands in; the full card materializes at turn completion (RFC D2).
+        """
+        etype = block.get("extracted_type") or ""
+        data = block.get("data")
+        if streaming:
+            return self._chat_extraction_status(etype)
+        if etype == "reflection":
+            return self._chat_reasoning_block(self._as_reflection_text(data),
+                                              summary="Reflection")
+        if etype == "todos":
+            return self._chat_todos_card(data)
+        if etype == "memory_updated":
+            return self._chat_memory_callout(data)
+        if etype == "skill_loaded":
+            return self._chat_skill_callout(data, loaded=True)
+        if etype == "skill_event":
+            return self._chat_skill_callout(data, loaded=False)
+        if etype == "compression_summary":
+            return self._chat_compression_callout(data)
+        if etype == "display_inline":
+            return self._chat_display_inline_block(data)
+        return self._chat_extraction_fallback(etype, data)
+
+    @staticmethod
+    def _chat_extraction_status(etype):
+        """A one-line live-bubble status for a mid-stream typed event."""
+        from dash import html
+        label = {
+            "reflection": "thinking...",
+            "todos": "todos updated",
+            "memory_updated": "memory updated",
+            "skill_loaded": "skill loaded",
+            "skill_event": "skill updated",
+            "compression_summary": "context compressed",
+            "display_inline": "rendering...",
+        }.get(etype, (etype or "event").replace("_", " "))
+        return html.Div(label, className="fd-chat-extraction-status")
+
+    @staticmethod
+    def _as_reflection_text(data):
+        """A reflection payload is a string (or a dict/other, coerced)."""
+        if isinstance(data, str):
+            return data
+        if isinstance(data, dict):
+            return str(data.get("reflection", data))
+        return str(data) if data is not None else ""
+
+    def _chat_todos_card(self, data):
+        """A task-list card: one row per todo with a status icon + text.
+
+        Completed items are struck through; unknown statuses fall back to the
+        pending look. ``data`` is a list of ``{"content"/"title", "status"}``.
+        """
+        from dash import html
+
+        import dash_mantine_components as dmc
+        from dash_iconify import DashIconify
+
+        items = data if isinstance(data, list) else []
+        _ICON = {
+            "completed": ("tabler:circle-check-filled", "green"),
+            "done": ("tabler:circle-check-filled", "green"),
+            "in_progress": ("tabler:loader-2", "blue"),
+            "in-progress": ("tabler:loader-2", "blue"),
+            "pending": ("tabler:circle", "gray"),
+        }
+        rows = []
+        for it in items:
+            if isinstance(it, dict):
+                text = it.get("content") or it.get("title") or it.get("task") or ""
+                status = str(it.get("status", "pending")).lower()
+            else:
+                text, status = str(it), "pending"
+            icon, color = _ICON.get(status, ("tabler:circle", "gray"))
+            done = status in ("completed", "done")
+            spin = "fd-chat-tool-spin" if status in ("in_progress", "in-progress") else ""
+            rows.append(dmc.Group(
+                [
+                    DashIconify(icon=icon, width=16, color=self._accent_color(color),
+                                className=spin),
+                    html.Span(str(text),
+                              className="fd-chat-todo-text"
+                              + (" fd-chat-todo-done" if done else "")),
+                ],
+                gap="xs", wrap="nowrap", className="fd-chat-todo-row",
+            ))
+        header = dmc.Group(
+            [
+                DashIconify(icon="tabler:list-check", width=16),
+                html.Span("Tasks", className="fd-chat-extraction-title"),
+            ],
+            gap="xs", wrap="nowrap",
+        )
+        return dmc.Paper([header] + rows, withBorder=True, radius="sm", p="xs",
+                         className="fd-chat-extraction fd-chat-todos")
+
+    def _chat_memory_callout(self, data):
+        """A compact one-line callout: 'Memory updated' + a short summary."""
+        summary = ""
+        if isinstance(data, dict):
+            action = data.get("action")
+            target = data.get("target")
+            bits = [b for b in (action, target) if b]
+            summary = " ".join(str(b) for b in bits)
+        return self._chat_extraction_callout(
+            "tabler:brain", "Memory updated", summary)
+
+    def _chat_skill_callout(self, data, loaded=True):
+        """A compact callout for a skill_loaded / skill_event typed event."""
+        if loaded:
+            chars = ""
+            if isinstance(data, dict) and data.get("body_chars"):
+                chars = "%s chars" % data["body_chars"]
+            return self._chat_extraction_callout(
+                "tabler:book", "Skill loaded", chars)
+        # skill_event (create / update / delete).
+        name = summary = ""
+        if isinstance(data, dict):
+            name = data.get("name") or ""
+            action = data.get("action") or ""
+            summary = (str(name) + (" (" + str(action) + ")" if action else "")).strip()
+        title = "Skill " + (str(name) if name else "event")
+        return self._chat_extraction_callout("tabler:tool", title, summary)
+
+    def _chat_compression_callout(self, data):
+        """A subtle divider-style callout: 'Context compressed' (+ details)."""
+        from dash import dcc, html
+
+        import dash_mantine_components as dmc
+        from dash_iconify import DashIconify
+
+        head = dmc.Group(
+            [
+                DashIconify(icon="tabler:arrows-minimize", width=14),
+                html.Span("Context compressed", className="fd-chat-extraction-title"),
+            ],
+            gap="xs", wrap="nowrap",
+        )
+        detail = None
+        if isinstance(data, dict):
+            parts = []
+            if "before_tokens" in data and "after_tokens" in data:
+                parts.append("%s -> %s tokens" % (data["before_tokens"], data["after_tokens"]))
+            if data.get("ratio"):
+                parts.append("%sx" % data["ratio"])
+            if data.get("reason"):
+                parts.append(str(data["reason"]))
+            if parts:
+                detail = dcc.Markdown(", ".join(parts),
+                                      className="fd-chat-extraction-detail")
+        body = [dmc.Divider(className="fd-chat-compression-divider"), head]
+        if detail is not None:
+            body.append(detail)
+        return dmc.Paper(body, radius="sm", p="xs",
+                         className="fd-chat-extraction fd-chat-compression")
+
+    def _chat_extraction_callout(self, icon, title, summary=""):
+        """A shared compact one-line callout chip: icon + title (+ summary)."""
+        from dash import html
+
+        import dash_mantine_components as dmc
+        from dash_iconify import DashIconify
+
+        row = [
+            DashIconify(icon=icon, width=16),
+            html.Span(str(title), className="fd-chat-extraction-title"),
+        ]
+        if summary:
+            row.append(html.Span(str(summary), className="fd-chat-extraction-summary"))
+        return dmc.Paper(
+            dmc.Group(row, gap="xs", wrap="nowrap"),
+            withBorder=True, radius="sm", p="xs",
+            className="fd-chat-extraction fd-chat-callout",
+        )
+
+    def _chat_display_inline_block(self, data):
+        """Render a display_inline payload inline, like an artifact.
+
+        The DisplayInlineExtractor returns ``{"display_type", "data", "title",
+        "status"}``. ``markdown`` / ``html`` / ``text`` render as text; a
+        ``table`` (list of dicts or a DataFrame-able) and any figure-shaped
+        payload route through the same artifact renderer figures/frames use, so
+        rich content lands inline exactly like an ``artifact`` frame.
+        """
+        from dash import dcc, html
+
+        import dash_mantine_components as dmc
+
+        if not isinstance(data, dict):
+            # A raw value (not the {display_type, data} envelope): render it as
+            # an artifact (figure / frame / image / text fallback).
+            return self._chat_artifact_block(data, streaming=False)
+
+        dtype = str(data.get("display_type", "")).lower()
+        payload = data.get("data")
+        title = data.get("title")
+        header = ([html.Div(str(title), className="fd-chat-extraction-title")]
+                  if title else [])
+
+        if dtype in ("markdown", "md", "text", ""):
+            body = dcc.Markdown(str(payload if payload is not None else ""),
+                                className="fd-chat-text", link_target="_blank")
+        elif dtype in ("table", "dataframe"):
+            body = self._chat_display_table(payload)
+        elif dtype in ("figure", "plotly", "chart"):
+            body = self._chat_display_figure(payload)
+        else:
+            # json / image / html and anything else: hand the payload to the
+            # artifact renderer, which figures out the best component.
+            body = self._chat_artifact_block(payload, streaming=False)
+
+        return dmc.Paper(header + [body], radius="sm", p="xs",
+                         className="fd-chat-extraction fd-chat-display-inline")
+
+    def _chat_display_table(self, payload):
+        """Render a display_inline table payload as a DataTable (best-effort)."""
+        try:
+            import pandas as pd
+            if not isinstance(payload, pd.DataFrame):
+                payload = pd.DataFrame(payload)
+            return self._chat_artifact_block(payload, streaming=False)
+        except Exception:
+            return self._chat_artifact_block(payload, streaming=False)
+
+    def _chat_display_figure(self, payload):
+        """Render a display_inline figure payload as a dcc.Graph (best-effort).
+
+        The payload may be a live ``go.Figure`` (route to the artifact renderer)
+        or a plotly figure dict (``{"data": [...], "layout": {...}}``), which the
+        artifact renderer does not recognize -- wrap it in a Graph directly.
+        """
+        from dash import dcc
+        try:
+            import plotly.graph_objects as go
+            if isinstance(payload, go.Figure):
+                return self._chat_artifact_block(payload, streaming=False)
+            if isinstance(payload, dict) and ("data" in payload or "layout" in payload):
+                return dcc.Graph(figure=payload, className="fd-chat-artifact",
+                                 style={"width": "100%"})
+        except Exception:
+            pass
+        return self._chat_artifact_block(payload, streaming=False)
+
+    def _chat_extraction_fallback(self, etype, data):
+        """Unknown extracted_type -> a compact, collapsible JSON card.
+
+        The safety net that guarantees a typed event is never dropped: it shows
+        the raw payload in a collapsible pre block labeled by its type.
+        """
+        from dash import html
+        return html.Details(
+            [
+                html.Summary(str(etype or "event"),
+                             className="fd-chat-reasoning-summary"),
+                html.Pre(self._chat_short_json(data),
+                         className="fd-chat-tool-result"),
+            ],
+            className="fd-chat-reasoning fd-chat-extraction-fallback",
+        )
+
+    @staticmethod
+    def _accent_color(color):
+        """Pass a Mantine color name through (kept as a hook for theming)."""
+        return color
 
     def _chat_bubble_json(self, component):
         """Serialize a Dash component to the plotly-json the reducer inserts."""
@@ -1486,6 +1770,16 @@ class ChatAppMixin:
                 _flush(True)
             elif t == "artifact":
                 blocks.append({"kind": "artifact", "content": frame["content"]}); _flush(True)
+            elif t == "extraction":
+                # A langstage typed-object event (todos / reflection / display_inline
+                # / skill / memory / compression / unknown). Joins the block list
+                # and is rendered server-side by _chat_extraction_block, so both
+                # transports (Flask op + ASGI full-state) show the same typed card.
+                blocks.append({"kind": "extraction",
+                               "extracted_type": frame.get("extracted_type", ""),
+                               "tool_name": frame.get("tool_name", ""),
+                               "data": frame.get("data")})
+                _flush(True)
             elif t == "set_input" and self.has_chat_sidecar:
                 # Per-verb gating: set_input is honored only if it's in the
                 # chat_tools allowlist. A refusal appends an italic note.

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -237,7 +237,8 @@ class _AutoAgentPlaceholder:
         # grammar so it streams as chat frames. (Guarded: if for some reason it
         # is already a plain (query, ctx) callable, use it as-is.)
         if is_langstage_target(graph):
-            return build_chat_callback(graph)
+            return build_chat_callback(
+                graph, getattr(self._app, "chat_extractors", None))
         return graph
 
     def __call__(self, query, ctx):
@@ -297,6 +298,7 @@ class FastDash(ChatAppMixin):
         chat_model=None,
         chat_title="Assistant",
         chat_placeholder=None,
+        chat_extractors=None,
         mcp_server=False,
         mcp_port=8001,
         mcp_host="127.0.0.1",
@@ -378,6 +380,17 @@ class FastDash(ChatAppMixin):
             steps (list of funcs, optional): A linear pipeline of step functions. Each step gets its own \
                 page in a stepper UI; outputs of earlier steps can feed downstream steps via ``from_step``. \
                 When provided, ``callback_fn`` is ignored. Defaults to None.
+
+            chat_extractors (iterable, optional): Extra typed-object extractors for a LangGraph chat agent. \
+                Each must satisfy the langstage ``ToolExtractor`` protocol (a ``tool_name`` string, an \
+                ``extracted_type`` string, and a callable ``extract(content)``). They are appended to the \
+                seven built-in extractors (think_tool, write_todos, memory, skill_view, skill_manage, \
+                compression, display_inline), deduped by ``tool_name`` with your extractor winning on a \
+                collision -- so you can override how a built-in tool renders. The matching extractor runs \
+                after each tool result and its non-None return is rendered as a typed card in the transcript. \
+                Only used for a LangGraph agent (a graph / spec string / auto-built assistant); a plain \
+                ``(query, ctx)`` chat callable ignores this silently. Entries are validated at construction. \
+                Defaults to None.
         """
 
         # Detect pipeline (steps) mode
@@ -432,11 +445,20 @@ class FastDash(ChatAppMixin):
         # (query, ctx) chat callable, or a model instance (auto-built agent).
         # The signature tiebreak: a callback whose first param is `query` is a
         # chat handler; otherwise it is an app callback. All errors are ASCII.
-        from .adapters.langstage import build_chat_callback, is_langstage_target
+        from .adapters.langstage import (
+            build_chat_callback,
+            is_langstage_target,
+            validate_extractors,
+        )
 
         self.chat_history_size = chat_history_size
         self.chat_title = chat_title or "Assistant"
         self.chat_model = chat_model
+        # Extra typed-object extractors appended to the built-in langstage
+        # defaults (deduped by tool_name, user winning). Duck-type validated
+        # here so a bad entry fails at construction, not mid-turn. Ignored by a
+        # non-langstage chat (a plain (query, ctx) callable) -- see the docstring.
+        self.chat_extractors = validate_extractors(chat_extractors)
         self.is_chat = False            # full-page chat mode
         self.has_chat_sidecar = False   # app + agent sidecar
         self.is_langstage = False
@@ -535,7 +557,7 @@ class FastDash(ChatAppMixin):
         if self.is_chat:
             target = self._chat_target
             if is_langstage_target(target):
-                target = build_chat_callback(target)
+                target = build_chat_callback(target, self.chat_extractors)
                 self.is_langstage = True
             self._chat_target = target
             self.callback_fn = callback_fn = target
@@ -2591,6 +2613,7 @@ def fastdash(
     chat_model=None,
     chat_title="Assistant",
     chat_placeholder=None,
+    chat_extractors=None,
     mcp_server=False,
     mcp_port=8001,
     mcp_host="127.0.0.1",
@@ -2713,6 +2736,7 @@ def fastdash(
             chat_model=chat_model,
             chat_title=chat_title,
             chat_placeholder=chat_placeholder,
+            chat_extractors=chat_extractors,
             mcp_server=mcp_server,
             mcp_port=mcp_port,
             mcp_host=mcp_host,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.6.0"
+version = "0.6.1"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -676,6 +676,366 @@ class TestLangstageAdapter:
         assert app.is_langstage is True
 
 
+class _DummyExtractor:
+    """A minimal ToolExtractor-protocol object for extractor-merge tests."""
+
+    def __init__(self, tool_name="my_tool", extracted_type="my_type"):
+        self.tool_name = tool_name
+        self.extracted_type = extracted_type
+
+    def extract(self, content):
+        return content
+
+
+class TestTypedExtractionBridge:
+    """The langstage bridge defaults to the built-in extractors (0.6.1)."""
+
+    @requires_langstage
+    def test_default_extractors_returns_the_seven_builtins(self):
+        from fast_dash.adapters.langstage import default_extractors
+        names = [e.tool_name for e in default_extractors()]
+        assert set(names) == {
+            "think_tool", "write_todos", "memory", "skill_view",
+            "skill_manage", "__compression__", "display_inline",
+        }
+        assert len(names) == 7
+
+    @requires_langstage
+    def test_build_chat_callback_passes_defaults_to_iter_event_frames(self):
+        # Patch iter_event_frames where the bridge imports it from and assert the
+        # seven defaults are passed on a turn.
+        from fast_dash.adapters.langstage import build_chat_callback
+        from fast_dash.chat import ChatContext
+        captured = {}
+
+        def fake_iter(agent, message, thread_id, **kwargs):
+            captured["extractors"] = kwargs.get("extractors")
+            async def _agen():
+                yield {"type": "content", "content": "ok"}
+            return _agen()
+
+        with mock.patch("langstage_core.agui.iter_event_frames", side_effect=fake_iter), \
+                mock.patch("langstage_core.agui.build_agent", return_value=object()):
+            cb = build_chat_callback("langstage_core.demo.stub:graph")
+            list(_drain(cb("hi", ChatContext(thread_id="t"))))
+        assert len(captured["extractors"]) == 7
+
+    @requires_langstage
+    def test_user_extractors_append_and_dedupe_user_wins(self):
+        from fast_dash.adapters.langstage import _merge_extractors
+        # A new tool_name appends.
+        merged = _merge_extractors([_DummyExtractor("my_tool", "my_type")])
+        assert len(merged) == 8
+        assert merged[-1].tool_name == "my_tool"
+        # A colliding tool_name replaces the built-in (user wins), no new slot.
+        override = _merge_extractors([_DummyExtractor("write_todos", "custom")])
+        assert len(override) == 7
+        by = {e.tool_name: e for e in override}
+        assert by["write_todos"].extracted_type == "custom"
+
+    def test_validate_rejects_non_protocol_entries_ascii(self):
+        from fast_dash.adapters.langstage import validate_extractors
+        assert validate_extractors(None) == []
+        with pytest.raises(TypeError) as ei:
+            validate_extractors([object()])
+        assert str(ei.value).isascii()
+        assert "extractor" in str(ei.value)
+
+    def test_chat_extractors_validated_at_construction(self):
+        # A non-protocol entry fails at FastDash construction, not mid-turn.
+        with pytest.raises(TypeError) as ei:
+            FastDash(callback_fn=lambda query: "x", chat=True,
+                     chat_extractors=[object()])
+        assert str(ei.value).isascii()
+
+    def test_non_langstage_chat_ignores_chat_extractors_silently(self):
+        # A plain (query, ctx) callable ignores chat_extractors (no error, still
+        # stored for a langstage target that never materializes here).
+        def bot(query):
+            yield "ok"
+        app = FastDash(callback_fn=bot, chat=True,
+                       chat_extractors=[_DummyExtractor()])
+        assert [e.tool_name for e in app.chat_extractors] == ["my_tool"]
+        with mock.patch("flask_socketio.emit"):
+            app._run_chat_turn("hi", "s1", "sock", ())
+        assert app.chat_history.get("s1")[-1]["content"] == "ok"
+
+    @requires_langstage
+    def test_construction_threads_extractors_into_the_turn(self):
+        from fast_dash.chat import ChatContext  # noqa: F401
+        captured = {}
+
+        def fake_iter(agent, message, thread_id, **kwargs):
+            captured["extractors"] = kwargs.get("extractors")
+            async def _agen():
+                yield {"type": "content", "content": "ok"}
+            return _agen()
+
+        with mock.patch("langstage_core.agui.iter_event_frames", side_effect=fake_iter), \
+                mock.patch("langstage_core.agui.build_agent", return_value=object()):
+            app = FastDash(callback_fn="langstage_core.demo.stub:graph", chat=True,
+                           chat_extractors=[_DummyExtractor()])
+            with mock.patch("flask_socketio.emit"):
+                app._run_chat_turn("hi", "s1", "sock", ())
+        assert len(captured["extractors"]) == 8
+        assert captured["extractors"][-1].tool_name == "my_tool"
+
+
+class TestExtractionFrameGrammar:
+    """The 'extraction' frame joins the grammar (real langstage wire shape)."""
+
+    def test_extraction_frame_normalizes(self):
+        f = _normalize_frame({
+            "type": "extraction", "tool_name": "write_todos",
+            "extracted_type": "todos",
+            "data": [{"content": "a", "status": "completed"}],
+        })
+        assert f["type"] == "extraction"
+        assert f["extracted_type"] == "todos"
+        assert f["tool_name"] == "write_todos"
+        assert f["data"] == [{"content": "a", "status": "completed"}]
+
+    def test_extraction_requires_extracted_type(self):
+        with pytest.raises(ChatFrameError) as ei:
+            _normalize_frame({"type": "extraction", "tool_name": "x", "data": 1})
+        assert str(ei.value).isascii()
+
+    def test_extraction_data_is_made_json_safe(self):
+        class Weird:
+            def __repr__(self):
+                return "<weird>"
+        f = _normalize_frame({"type": "extraction", "extracted_type": "custom",
+                              "data": {"obj": Weird()}})
+        json.dumps(f)                                  # must not raise
+        assert f["data"] == {"obj": "<weird>"}
+
+    def test_unknown_frame_still_warns_and_skips(self):
+        # Sanity: the new type didn't break the warn+skip contract for others.
+        with pytest.warns(UserWarning, match="Unknown chat frame type"):
+            assert _normalize_frame({"type": "not_extraction", "x": 1}) is None
+
+
+class TestExtractionRenderers:
+    """One renderer per extracted_type; every render is JSON-safe (no browser)."""
+
+    def _app(self):
+        return FastDash(callback_fn=lambda query: iter(["x"]), chat=True)
+
+    def _render(self, app, etype, data, streaming=False):
+        block = {"kind": "extraction", "extracted_type": etype,
+                 "data": data, "tool_name": "t"}
+        comp = app._chat_extraction_block(block, streaming=streaming)
+        app._chat_bubble_json(comp)                    # must serialize cleanly
+        return comp
+
+    def test_reflection_reuses_reasoning_block(self):
+        app = self._app()
+        comp = self._render(app, "reflection", "I should check the data.")
+        js = app._chat_bubble_json(comp)
+        # A collapsible details block labeled Reflection.
+        assert "Reflection" in json.dumps(js)
+
+    def test_todos_card_has_status_icons_and_strikethrough(self):
+        app = self._app()
+        data = [{"content": "one", "status": "completed"},
+                {"content": "two", "status": "in_progress"},
+                {"content": "three", "status": "pending"},
+                {"content": "weird", "status": "bogus"}]
+        js = json.dumps(app._chat_bubble_json(self._render(app, "todos", data)))
+        # Completed item is struck through; distinct status icons are present.
+        assert "fd-chat-todo-done" in js
+        assert "tabler:circle-check-filled" in js       # completed
+        assert "tabler:loader-2" in js                   # in_progress
+        assert "tabler:circle" in js                     # pending / unknown
+        # Unknown status did not crash and rendered as a row.
+        assert "weird" in js
+
+    def test_memory_callout(self):
+        app = self._app()
+        js = json.dumps(app._chat_bubble_json(
+            self._render(app, "memory_updated", {"action": "add", "target": "MEMORY.md"})))
+        assert "Memory updated" in js
+
+    def test_skill_loaded_and_skill_event_callouts(self):
+        app = self._app()
+        loaded = json.dumps(app._chat_bubble_json(
+            self._render(app, "skill_loaded", {"loaded": True, "body_chars": 1234})))
+        assert "Skill loaded" in loaded
+        event = json.dumps(app._chat_bubble_json(
+            self._render(app, "skill_event",
+                         {"action": "create", "name": "pdf-merging"})))
+        assert "Skill" in event and "pdf-merging" in event
+
+    def test_compression_callout(self):
+        app = self._app()
+        js = json.dumps(app._chat_bubble_json(self._render(
+            app, "compression_summary",
+            {"before_tokens": 47000, "after_tokens": 9000, "ratio": 5})))
+        assert "Context compressed" in js
+
+    def test_display_inline_markdown_renders_text(self):
+        app = self._app()
+        comp = self._render(app, "display_inline",
+                            {"display_type": "markdown", "data": "# Result", "title": "R"})
+        js = json.dumps(app._chat_bubble_json(comp))
+        assert "Markdown" in js                         # dcc.Markdown component
+        assert "Result" in js
+
+    def test_display_inline_table_renders_a_datatable(self):
+        app = self._app()
+        # A table payload is coerced to a DataFrame and handed to the same
+        # artifact renderer figures/frames use, which renders a DataTable.
+        comp = self._render(app, "display_inline",
+                            {"display_type": "table",
+                             "data": [{"a": 1, "b": 2}, {"a": 3, "b": 4}]})
+        js = json.dumps(app._chat_bubble_json(comp))
+        assert "DataTable" in js
+        assert "fd-chat-display-inline" in js           # wrapped in the card
+
+    def test_display_inline_figure_routes_through_artifact(self):
+        import plotly.graph_objects as go
+        app = self._app()
+        # A raw figure value (no envelope) goes straight to the artifact renderer.
+        block = {"kind": "extraction", "extracted_type": "display_inline",
+                 "data": go.Figure(), "tool_name": "display_inline"}
+        js = json.dumps(app._chat_bubble_json(
+            app._chat_extraction_block(block, streaming=False)))
+        assert "Graph" in js                            # dcc.Graph
+
+    def test_display_inline_figure_dict_envelope_renders_a_graph(self):
+        app = self._app()
+        # A {display_type: figure, data: <plotly dict>} envelope renders a Graph.
+        comp = self._render(app, "display_inline",
+                            {"display_type": "figure",
+                             "data": {"data": [{"x": [1, 2], "y": [3, 4],
+                                                "type": "scatter"}],
+                                      "layout": {}}})
+        js = json.dumps(app._chat_bubble_json(comp))
+        assert "Graph" in js
+        assert "fd-chat-display-inline" in js
+
+    def test_unknown_extracted_type_falls_back_to_json_card(self):
+        app = self._app()
+        comp = self._render(app, "totally_unknown", {"anything": [1, 2, 3]})
+        js = json.dumps(app._chat_bubble_json(comp))
+        assert "totally_unknown" in js                  # labeled by its type
+        assert "fd-chat-extraction-fallback" in js
+
+    def test_streaming_shows_a_one_line_status(self):
+        app = self._app()
+        comp = self._render(app, "todos", [{"content": "x", "status": "pending"}],
+                            streaming=True)
+        js = json.dumps(app._chat_bubble_json(comp))
+        assert "fd-chat-extraction-status" in js
+        assert "todos updated" in js
+
+    def test_extraction_block_never_dropped_in_full_bubble(self):
+        app = self._app()
+        blocks = [
+            {"kind": "text", "text": "Working."},
+            {"kind": "extraction", "extracted_type": "todos",
+             "data": [{"content": "x", "status": "completed"}], "tool_name": "write_todos"},
+            {"kind": "extraction", "extracted_type": "display_inline",
+             "data": {"display_type": "markdown", "data": "**done**"},
+             "tool_name": "display_inline"},
+        ]
+        for streaming in (True, False):
+            app._chat_bubble_json(app._chat_assistant_bubble(blocks, streaming=streaming))
+
+
+def _tool_calling_graph():
+    """A keyless LangGraph whose tools return todos + display_inline content."""
+    import json as _json
+
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+    from langgraph.checkpoint.memory import InMemorySaver
+    from langgraph.graph import END, START, MessagesState, StateGraph
+    from langgraph.prebuilt import ToolNode
+
+    @tool
+    def write_todos(todos: list) -> str:
+        """Write the current todo list."""
+        return _json.dumps([{"content": "one", "status": "completed"},
+                            {"content": "two", "status": "in_progress"}])
+
+    @tool
+    def display_inline(display_type: str, data: str) -> str:
+        """Render rich content inline."""
+        return _json.dumps({"display_type": "markdown", "data": "# Result",
+                            "title": "Report"})
+
+    step = {"n": 0}
+
+    def agent_node(state):
+        step["n"] += 1
+        if step["n"] == 1:
+            return {"messages": [AIMessage(content="", tool_calls=[
+                {"id": "c1", "name": "write_todos", "args": {"todos": []}},
+                {"id": "c2", "name": "display_inline",
+                 "args": {"display_type": "markdown", "data": "x"}},
+            ])]}
+        return {"messages": [AIMessage(content="All done.")]}
+
+    def route(state):
+        return "tools" if getattr(state["messages"][-1], "tool_calls", None) else END
+
+    g = StateGraph(MessagesState)
+    g.add_node("agent", agent_node)
+    g.add_node("tools", ToolNode([write_todos, display_inline]))
+    g.add_edge(START, "agent")
+    g.add_conditional_edges("agent", route, {"tools": "tools", END: END})
+    g.add_edge("tools", "agent")
+    return g.compile(checkpointer=InMemorySaver())
+
+
+class TestExtractionEndToEnd:
+    """A real tool-calling graph streams typed blocks into the transcript."""
+
+    @requires_langstage
+    def test_turn_yields_todos_and_display_inline_blocks(self):
+        app = FastDash(callback_fn=_tool_calling_graph(), chat=True)
+        assert app.is_langstage is True
+
+        seen = {}
+        orig = app._chat_assistant_bubble
+
+        def spy(blocks, streaming=False):
+            if not streaming:
+                seen["kinds"] = [b.get("kind") for b in blocks]
+                seen["etypes"] = [b.get("extracted_type") for b in blocks
+                                  if b.get("kind") == "extraction"]
+            return orig(blocks, streaming=streaming)
+        app._chat_assistant_bubble = spy
+
+        with mock.patch("flask_socketio.emit"):
+            app._run_chat_turn("go", "s1", "sock", ())
+
+        assert "extraction" in seen["kinds"]
+        assert "todos" in seen["etypes"]
+        assert "display_inline" in seen["etypes"]
+        # History stores only the assistant text, not the typed-event noise.
+        assert app.chat_history.get("s1")[-1]["content"] == "All done."
+
+
+def _drain(gen):
+    """Drive a sync-or-async generator to a flat list (test helper)."""
+    if hasattr(gen, "__anext__"):
+        import asyncio as _asyncio
+        loop = _asyncio.new_event_loop()
+        out = []
+        try:
+            while True:
+                try:
+                    out.append(loop.run_until_complete(gen.__anext__()))
+                except StopAsyncIteration:
+                    break
+        finally:
+            loop.close()
+        return out
+    return list(gen)
+
+
 def _interrupt_graph():
     """A keyless LangGraph that interrupts once, then echoes the decision."""
     from langchain_core.messages import AIMessage


### PR DESCRIPTION
LangGraph agents (chat mode, sidecar, and auto-agent — all three bridge paths) now stream through langstage-core's typed extractor layer **by default**, and the transcript renders each typed event natively:

| extracted_type | Renderer |
|---|---|
| `reflection` | collapsible thinking block |
| `todos` | task-list card (status icons, strikethrough on done) |
| `memory_updated` | compact callout |
| `skill_loaded` / `skill_event` | skill callouts |
| `compression_summary` | divider callout |
| `display_inline` | **artifact pipeline**: figures / DataFrames / markdown render inline |
| *(unknown)* | collapsible JSON card — never dropped |

- `chat_extractors=` accepts custom `ToolExtractor`-protocol objects, appended to the built-ins (user wins on `tool_name` collision); duck-type validated with friendly errors.
- `extraction` added to the frame grammar with JSON-safe normalization; malformed frames warn+skip.
- Fixes two latent artifact bugs found en route: `DataTable` `className` fallback (chat DataFrames silently rendered as markdown) and plotly figure-dict payloads rendering as text.

453 passed locally (24 new; 3 known local-env selenium deselects — CI is the browser arbiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)