### PR TITLE
docs: changelog + docs currency pass through 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,72 @@
-# Release 0.4.1
+# Release 0.6.2
+
+## 0.6.2 (2026-07-12)
+
+### Added
+- **Collapsible input accordion for chat sidebars.** A long input list can now
+  tuck to a header instead of crowding the conversation. In full-page chat the
+  inputs are secondary "Settings (N)" (collapsed by default when there are
+  many); in a sidecar they are the primary "Inputs (N)" (open by default).
+  Normal (non-chat) form apps are unchanged.
+
+## 0.6.1 (2026-07-07)
+
+### Changed
+- **Typed agent events by default.** langstage extractors and chat renderers
+  emit typed frames, so chat surfaces render structured agent events out of the
+  box.
+
+## 0.6.0 (2026-07-07)
+
+### Added
+- **Unified `chat=` API (RFC #145).** `chat=` is now polymorphic — pass `True`,
+  a compiled agent graph, a spec string, or an agent callable — with a
+  `chat_tools` allowlist and a collapsible sidebar panel.
+- **Agent app toolkit + runtime layout/content engine**, with sandboxed
+  execution, an auto-agent bridge, and human-in-the-loop (HITL) execution.
+
+### Changed
+- **Breaking:** the unified `chat=` argument supersedes the earlier per-mode
+  chat flags. Update code that used the pre-0.6 chat parameters to pass the
+  agent (or `True`) directly via `chat=`.
+
+## 0.5.5 (2026-07-05)
+
+### Bug fixes
+- Correct the sidebar-chat navbar width so the output area and the collapse
+  affordance align.
+
+## 0.5.4 (2026-07-05)
+
+### Added
+- **`chat_agent_position="sidebar"`** — render the chat panel inside the inputs
+  sidebar (the sidecar placement) rather than as a separate surface.
+
+## 0.5.3 (2026-07-05)
+
+### Added
+- Mode-aware, customizable empty-transcript placeholder for chat apps.
+
+## 0.5.2 (2026-07-04)
+
+### Bug fixes
+- The chat sidecar's `run_app` now renders outputs, not just inputs.
+
+## 0.5.1 (2026-07-04)
+
+### Bug fixes
+- Make the `describe_app()` MCP contract consistent and surface date defaults.
+
+## 0.5.0 (2026-07-03)
+
+### Added
+- **Chat mode (`chat=True`) and the agent sidecar (`chat=<agent>`).** Turn a
+  `query`-first callback into a full-page chat app, or attach a chat assistant
+  to a normal form app that can read and drive its inputs.
+- **UI refresh.** A Mantine-based design foundation (accent-color API, richer
+  theme), polished chrome/inputs/outputs, motion + accessibility + mobile
+  support, skeleton loaders and a pre-run empty state, and input help captions
+  inferred from the callback docstring. FontAwesome dropped.
 
 ## 0.4.1 (2026-07-01)
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ def assistant(query: str):
 ```
 
 `yield` strings to stream the reply as markdown; add a `history` parameter for
-multi-turn memory, and any other parameter becomes a sidebar setting. `chat=`
-also accepts a LangGraph graph, a `(query, ctx)` callable, or a chat-model
-instance.
+multi-turn memory, and any other parameter becomes a sidebar setting (tucked
+into a collapsible accordion when there are many). `chat=` also accepts a
+LangGraph graph, a `(query, ctx)` callable, or a chat-model instance.
 
 Or keep a **normal** app and add an assistant beside it — pass your agent as
 `chat=`: the agent reads your app's live inputs (`ctx.inputs`) and can drive it

--- a/docs/User guide/chat.md
+++ b/docs/User guide/chat.md
@@ -70,6 +70,15 @@ def assistant(
 box. Their live values are passed to the callback each turn, rendered in the
 **sidebar** above (or beside) the transcript.
 
+!!! tip "Collapsible settings (0.6.2+)"
+    Settings render inside a **fully-collapsible accordion** so a long list
+    doesn't crowd the conversation. In full-page chat mode it's a
+    "Settings (N)" panel that defaults collapsed when there are many settings
+    (open when there are only a few). In a [sidecar](#add-an-assistant-to-a-normal-app-a-chat-sidecar)
+    the app's own inputs are the primary interface, so the "Inputs (N)" panel
+    defaults **open** and can be tucked to a header to give the chat more room —
+    and collapsing the chat panel expands the inputs to full height.
+
 ## The frame grammar
 
 Yielding a `str` is sugar for a text frame. For richer replies, `yield` frame

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,29 @@
 # History
 
+# Release 0.6.2
+
+## 0.6.2 (2026-07-12)
+
+Chat sidebars get a **collapsible input accordion**, so a long list of settings
+(or, in a sidecar, the app's own inputs) can tuck to a header instead of
+crowding the conversation.
+
+### Added
+
+- **Collapsible "Settings" / "Inputs" accordion in chat sidebars.** The sidebar
+  inputs are wrapped in a fully-collapsible `dmc.Accordion` — a single-mode item
+  that closes completely on click — scoped to chat surfaces; a normal (non-chat)
+  form app is unchanged.
+    - **Full-page chat (`chat=True`)**: the inputs are secondary settings, shown
+      as a **"Settings (N)"** panel that defaults *collapsed* when there are
+      several (and open when there are only a few), keeping the transcript roomy.
+    - **Sidecar (`chat=<agent>`)**: the app's own inputs are the primary
+      interface, shown as an **"Inputs (N)"** panel that defaults *open*; it only
+      adds a way to tuck them so the chat panel can reclaim the space. The
+      accordion stays inside the input container and never touches the chat
+      panel — collapsing the chat panel still lifts the height cap so the inputs
+      show in full.
+
 # Release 0.6.1
 
 ## 0.6.1 (2026-07-07)


### PR DESCRIPTION
Documentation currency pass through 0.6.2.

- **`docs/history.md`** (the maintained changelog shown on the docs site): add the **0.6.2** entry — collapsible input accordion for chat sidebars.
- **`docs/User guide/chat.md`**: document the collapsible Settings/Inputs accordion under "Developer-declared settings".
- **README**: note the chat sidebar settings tuck into a collapsible accordion when there are many.
- **`CHANGELOG.md`**: backfill 0.5.0 → 0.6.2 (it had drifted to 0.4.1).

**Heads-up on the two changelogs:** `docs/history.md` is the detailed, reader-facing one; `CHANGELOG.md` is regenerated by `release.yml` for the GitHub release body and had gone stale in the repo. Worth consolidating (e.g. make `CHANGELOG.md` point at the docs history) so they can't drift again — happy to do that in a follow-up.

Docs-only; no version bump. Validated with a local `mkdocs build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
