### PR TITLE
fix: make the agent contract trustworthy (0.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,31 @@
-# Release 0.6.2
+# Release 0.6.3
+
+## 0.6.3 (2026-07-13)
+
+An agent-contract release: the MCP surface now describes what an app really is,
+and refuses what its UI could never produce.
+
+### Fixed
+- **`Tuple[int, str]` return hints silently dropped outputs** (#156) — the
+  idiomatic spellings collapsed to one output; only bare `-> (int, str)` worked.
+- **Apps shared one mutable-default `run_kwargs` dict** (#153) — constructing a
+  second app rewrote the first's port, so `run()` bound the wrong one.
+- **`PasswordInput` values leaked over the no-auth MCP route** (#151) — secrets
+  now go in but never come back out (`"secret": true`, masked values).
+- **Value validation was type-blind** (#150) — a string slipped past a Slider's
+  min/max; numeric and boolean inputs now reject the wrong JSON type.
+- **`DynamicDash` forms skipped all validation** (#144) — the form currently on
+  screen (`initial_specs`, a `parent_control` cascade, or an agent's `set_form`)
+  is now the contract enforced against, parent control included.
+- **The MCP no-auth warning watched the defunct `mcp_host`** (#149) — it now
+  fires at `run()`, keyed off the host actually bound.
+- **All `str` widgets reported tag `"Text"`** (#147) — a colour picker, textarea
+  and text box now each report the widget they became.
+
+### Added
+- **Output contract in `describe_app`** (#152) — agents can discover what a run
+  produces (id, component tag, JSON type, label) without side-effectingly
+  calling `invoke()`.
 
 ## 0.6.2 (2026-07-12)
 

--- a/docs/User guide/ai_agents.md
+++ b/docs/User guide/ai_agents.md
@@ -5,9 +5,9 @@
 Pass `mcp_server=True` and your Fast Dash app serves a web UI **and** a
 [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server, so any
 MCP-capable agent — Claude Code, Cursor, Cline, … — can inspect and drive it.
-The same type hints that build the UI describe the inputs an agent sees via the
-[`describe_app`](#discover-the-input-contract) tool (id, type, default, allowed
-options, and current value).
+The same type hints that build the UI describe what an agent sees via the
+[`describe_app`](#discover-the-contract) tool: every input (id, type, default,
+allowed options, current value) and every output the app produces.
 
 The MCP server is built on [Dash's native MCP support](https://dash.plotly.com)
 (Dash ≥ 4.3, installed automatically) and is mounted on the **same port** as the
@@ -35,7 +35,7 @@ Point any MCP client at the app's `/mcp` endpoint (streamable HTTP):
 
 | Surface | Provided by | Use |
 |---|---|---|
-| `describe_app()` | Fast Dash | **Start here.** The input contract + current state: each input's id, type, default, options, and current value |
+| `describe_app()` | Fast Dash | **Start here.** The full contract + current state: each input's id, type, default, options and current value, and each output the app produces |
 | `set_input(component_id, value)` | Fast Dash | Set one input |
 | `set_inputs(inputs)` | Fast Dash | Set several inputs at once (`inputs` is a `{id: value}` dict) |
 | `invoke(inputs=None)` | Fast Dash | Run the callback (optionally setting inputs first), in one call |
@@ -46,22 +46,46 @@ Point any MCP client at the app's `/mcp` endpoint (streamable HTTP):
 
 `component_id` is the **parameter name** itself (e.g. `"n"`, `"color"`).
 
-### Discover the input contract
+### Discover the contract
 
 Call **`describe_app()`** to learn the exact input ids, their Python types,
-defaults, allowed options, and **current values** — and use that to build a valid
-`invoke` call:
+defaults, allowed options and **current values**, plus what a run produces — and
+use that to build a valid `invoke` call:
 
 ```json
 {
   "title": "Plot Bars",
   "doc": "Plot a bar chart with n bars in the chosen color.",
   "inputs": [
-    {"id": "n",     "type": "integer", "default": 6,         "options": null, "current_value": 6},
-    {"id": "color", "type": "string",  "default": "#1c7ed6", "options": null, "current_value": "#1c7ed6"}
+    {"id": "n",     "tag": "Slider",     "type": "integer", "default": 6,         "options": null, "current_value": 6,         "secret": false},
+    {"id": "color", "tag": "ColorInput", "type": "string",  "default": "#1c7ed6", "options": null, "current_value": "#1c7ed6", "secret": false}
+  ],
+  "outputs": [
+    {"id": "output_go_Figure", "tag": "Graph", "type": "object", "label": "Bar chart"}
   ]
 }
 ```
+
+`tag` is the widget the hint became — a `str` input can be a text box, a
+textarea or a colour picker, and they are not interchangeable. `outputs` lets an
+agent see what a run returns **without** having to run it.
+
+### The contract is enforced
+
+Whatever `describe_app()` advertises is what `set_input` / `set_inputs` /
+`invoke` accept — an agent cannot set a value the UI itself could never produce.
+A value outside a dropdown's `options`, outside a Slider's `min`/`max`, or of the
+wrong type (a string for a number, a string for a switch) is rejected with an
+error naming the constraint, and `invoke` is atomic: one bad value rejects the
+whole call without mutating anything. The same holds for a form an agent builds
+at runtime with `set_form` — the specs it declared become the contract it is
+then held to.
+
+!!! warning "Secrets"
+    A `PasswordInput`'s value is **never reported back** over MCP: the contract
+    marks it `"secret": true` and masks it everywhere (`describe_app`, the
+    `set_input` echo, `get_invocation`). An agent can fill the field; it cannot
+    read it.
 
 !!! note
     The drive tools' (`invoke` / `set_inputs` / `set_input`) raw MCP *input
@@ -117,7 +141,8 @@ After `set_form`, **`describe_app()` reflects the materialized form** — each f
 `id`, `type`, `default`, `options`, and `props` (e.g. a slider's `min`/`max`) plus
 its current value — so a reconnecting (or second) agent can discover and drive the
 form without remembering the spec it sent. From there, `set_inputs(...)` + `invoke()`
-run it.
+run it, validated against the very specs the form was built from: a value outside
+that slider's `0..10` is rejected exactly as it would be on a static app.
 
 ## Real-time push (opt-in)
 
@@ -150,7 +175,8 @@ The same ASGI backend also powers native-WebSocket **streaming** for
     The MCP route shares the web app's host/port and has **no authentication** —
     anyone who can reach it can drive your callback. Keep it bound to
     `127.0.0.1` (the default) during development, and put it behind your own
-    auth before exposing it.
+    auth before exposing it. Serving on a non-loopback host (e.g.
+    `run_kwargs={"host": "0.0.0.0"}`) with `mcp_server=True` raises a warning.
 
 - **One MCP-enabled app per process** (Dash's tool registry is process-global).
 - **Multi-function and steps modes** skip the MCP surface.

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,77 @@
 # History
 
+# Release 0.6.3
+
+## 0.6.3 (2026-07-13)
+
+An **agent-contract** release: the MCP surface now describes what an app really
+is, and refuses what its UI could never produce. Every open bug at the time of
+writing is fixed.
+
+### Fixed
+
+- **`Tuple[int, str]` return hints silently dropped outputs** ([#156]). Only the
+  bare parenthesized spelling `-> (int, str)` produced two outputs; the
+  idiomatic `Tuple[int, str]` / `tuple[int, str]` are generic *aliases*, not
+  tuple objects, so they collapsed to a single output and every return value
+  after the first was discarded. Both spellings now expand, including under
+  `from __future__ import annotations` (where the hint arrives as a string), and
+  a variadic `tuple[int, ...]` correctly stays a single output.
+- **Apps shared one `run_kwargs` dict** ([#153]). `run_kwargs=dict()` was a
+  mutable default that the constructor then mutated with its own port, so
+  building a second app silently rewrote the first app's port (and any other
+  `run_kwargs`, including the security-relevant `host`) — `app.run()` bound the
+  wrong port. `run_kwargs` is now copied, never aliased, and the caller's dict is
+  left untouched.
+- **`PasswordInput` values leaked over the no-auth MCP route** ([#151]). The chat
+  surface redacted secrets; the MCP surface handed them out in plain text via
+  `describe_app`, the `set_input` echo, and `get_invocation`. A password's value
+  now goes *in* (an agent can still fill the field) but never comes back out:
+  the contract marks the input `"secret": true` and every value it reports is
+  masked — including a secret carried in a spec's `props`, and one whose form
+  has since been replaced (its value is dropped from the mirror with it).
+- **Value validation was type-blind** ([#150]). The range check only fired for
+  numbers, so a *string* sailed straight past a Slider's `min`/`max` — `"9999"`
+  is not an `int`, so nothing compared it to the maximum — and reached the
+  callback as a value no drag of the slider could produce. Numeric and boolean
+  inputs now reject values of the wrong JSON type.
+- **`DynamicDash` forms skipped all validation** ([#144]). Every guard keyed off
+  the *static* input list, which a `DynamicDash` doesn't have, so unknown ids,
+  out-of-options values and out-of-range slider values were all accepted in
+  silence. The specs of the form **currently on screen** are now the contract
+  that `set_input` / `set_inputs` / `invoke` enforce against — whether that form
+  came from `initial_specs`, a `parent_control` cascade, or an agent's
+  `set_form` (including `[{"label": ..., "value": ...}]` style `Select` options).
+  The parent control is part of the contract too: the UI passes it to the
+  callback, so an agent can discover and drive it.
+- **The MCP no-auth warning watched the wrong knob** ([#149]). It warned on
+  `mcp_host`, which stopped binding anything when MCP moved onto the app's own
+  port, and stayed silent on the setting that actually exposes an
+  unauthenticated tool endpoint: serving on `0.0.0.0`. It now fires at `run()`,
+  keyed off the host the server really binds.
+- **All `str` widgets reported the same tag** ([#147]). A colour picker, a
+  textarea and a text box all described themselves as `"Text"`, so a headless
+  agent reading `describe_app` couldn't tell them apart. Each now reports the
+  widget it actually became (`ColorInput` / `TextArea` / `Text`).
+
+### Added
+
+- **Output contract in `describe_app`** ([#152]). It reported inputs only, so the
+  one way for a headless agent to learn what an app returns was to *call* it —
+  discovery by side effect. `describe_app` now also lists each output's `id`,
+  the component `tag` it renders into (`Graph` / `Table` / `Markdown` / …), its
+  JSON `type` and `label`, plus a summary of the value currently on screen once
+  something has run.
+
+[#144]: https://github.com/dkedar7/fast_dash/issues/144
+[#147]: https://github.com/dkedar7/fast_dash/issues/147
+[#149]: https://github.com/dkedar7/fast_dash/issues/149
+[#150]: https://github.com/dkedar7/fast_dash/issues/150
+[#151]: https://github.com/dkedar7/fast_dash/issues/151
+[#152]: https://github.com/dkedar7/fast_dash/issues/152
+[#153]: https://github.com/dkedar7/fast_dash/issues/153
+[#156]: https://github.com/dkedar7/fast_dash/issues/156
+
 # Release 0.6.2
 
 ## 0.6.2 (2026-07-12)

--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import math
 import numbers
+import types
 import warnings
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass, field
@@ -1369,15 +1370,19 @@ def _get_component_from_input(hint, default_value=None):
             # A short single-line string is a single-line TextInput; a hex color
             # is a swatch picker; only genuinely long / multi-line text gets a
             # Textarea. (Previously every str became a tall Textarea.)
+            # The tag must name the widget actually chosen, not the `str` hint —
+            # otherwise describe_app() collapses a colour picker, a textarea and a
+            # text box to the same tag: "Text", and a headless agent can't tell
+            # them apart (#147).
             if _is_hex_color(default_value):
                 component = Fastify(
-                    dmc.ColorInput(value=default_value), "value", tag=_hint_type
+                    dmc.ColorInput(value=default_value), "value", tag="ColorInput"
                 )
             elif "\n" in default_value or len(default_value) > 120:
                 component = Fastify(
                     dmc.Textarea(value=default_value, autosize=True, minRows=3),
                     "value",
-                    tag=_hint_type,
+                    tag="TextArea",
                 )
             else:
                 component = Fastify(
@@ -1824,6 +1829,26 @@ def _infer_input_components(func):
     return components
 
 
+def expand_return_annotation(annotation):
+    """One entry per value the function returns, given its return annotation.
+
+    A bare parenthesized annotation ``-> (int, str)`` is a real tuple object,
+    but the idiomatic PEP 484 / PEP 585 spellings ``Tuple[int, str]`` and
+    ``tuple[int, str]`` are generic *aliases* — ``isinstance(ann, tuple)`` is
+    False for them, so they used to collapse to a single output and silently
+    drop every return value after the first (#156). Expand those via
+    ``get_origin`` / ``get_args``.
+    """
+    if isinstance(annotation, tuple):
+        return list(annotation)
+    if get_origin(annotation) is tuple:
+        args = list(get_args(annotation))
+        # A variadic `tuple[int, ...]` has no fixed arity, so we can't infer an
+        # output count from it — fall back to a single output.
+        return [annotation] if (not args or Ellipsis in args) else args
+    return [annotation]
+
+
 def _infer_output_components(func, outputs, output_labels):
     signature = inspect.signature(func)
     components = []
@@ -1835,13 +1860,24 @@ def _infer_output_components(func, outputs, output_labels):
         parameters = [(None, outputs)]
 
     else:
-        parameters = list(
-            enumerate(
-                signature.return_annotation
-                if isinstance(signature.return_annotation, tuple)
-                else [signature.return_annotation]
-            )
-        )
+        annotation = signature.return_annotation
+        if isinstance(annotation, str):
+            # Under `from __future__ import annotations` every hint reaches us as
+            # a string, so `Tuple[int, str]` would never even be recognized as a
+            # tuple (#156). Resolve it the same way the inputs path does; if the
+            # name isn't importable from the user's module we keep the string and
+            # fall through to the by-name handling in _get_output_components.
+            try:
+                resolved = eval(annotation, getattr(func, "__globals__", {}))  # noqa: S307 - user's own annotation, user's own module
+            except Exception:
+                resolved = None
+            # `from PIL import Image` binds a *module* to the name, and
+            # `_get_output_components` has a by-name fallback for exactly that
+            # spelling. Resolving it would hand that path a module object, which
+            # matches no hint, and a returned picture would render as an <h1>.
+            if resolved is not None and not isinstance(resolved, types.ModuleType):
+                annotation = resolved
+        parameters = list(enumerate(expand_return_annotation(annotation)))
 
     if output_labels is None:
         output_labels = [None] * len(parameters)

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/dynamic.py
+++ b/fast_dash/dynamic.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 import copy
 import inspect
-import warnings
 from typing import Any, Callable, Iterable
 
 import dash
@@ -244,14 +243,13 @@ class DynamicDash:
         if self.mcp_server_enabled:
             from fast_dash.mcp import MCPState
             self._mcp_state = MCPState()
-            if mcp_host not in ("127.0.0.1", "localhost"):
-                warnings.warn(
-                    f"mcp_host={mcp_host!r} binds the MCP port to a non-loopback "
-                    "address. The MCP port has no authentication; anyone who can "
-                    "reach it can invoke your callback. Use 127.0.0.1 unless you "
-                    "have a deliberate reason to expose it.",
-                    stacklevel=2,
-                )
+            # The form on screen at startup is the contract an agent connects to.
+            # Without this, an app-authored form (initial_specs / placeholder) had
+            # no MCP contract at all: no ids to check, no bounds to enforce, no
+            # PasswordInput to mask — only a form the agent built itself did.
+            self._mcp_state.set_current_specs(self.initial_specs)
+            # The exposure warning lives in run(), keyed off the host we
+            # actually bind to -- see mcp.warn_if_exposed (#149).
 
         sig = inspect.signature(callback_fn)
         self._has_var_kw = any(
@@ -379,12 +377,28 @@ class DynamicDash:
             )
         )
 
+    def _sync_form_contract(self, specs, parent_value=None):
+        """Point the MCP contract at the form the parent cascade just rendered.
+
+        The cascade replaces the form, so it replaces the contract. Without this
+        an agent reading ``describe_app`` would still see whatever a previous
+        ``set_form`` left behind — and the validators would enforce *those* ids
+        while rejecting the ones actually on screen.
+        """
+        if self._mcp_state is None:
+            return
+        parent_name = (self.parent_control or {}).get("name")
+        self._mcp_state.set_current_specs(specs, keep={parent_name} - {None})
+        if parent_name and parent_value is not None:
+            self._mcp_state.inputs[parent_name] = parent_value
+
     def _register_callbacks(self):
         app = self.app
 
         # ----- (i) parent control → form (form-driven) -----------------------
         if self.parent_control is not None and self.spec_resolver is not None:
             resolver = self.spec_resolver
+            parent_name = self.parent_control.get("name")
 
             @app.callback(
                 Output("dyn-form", "children"),
@@ -399,9 +413,11 @@ class DynamicDash:
                 except Exception:
                     return no_update
                 try:
-                    return render_spec(specs).children
+                    children = render_spec(specs).children
                 except Exception:
                     return no_update
+                self._sync_form_contract(specs, parent_value)
+                return children
 
         # ----- (ii) MCP set_form → form (agent-driven, v0.2 drain) -----------
         # An external agent calls the set_form MCP tool, which writes the
@@ -540,8 +556,9 @@ class DynamicDash:
         if port is None:
             port = self._port if self._port is not None else 8050
         if self.mcp_server_enabled:
-            from fast_dash.mcp import enable_mcp
+            from fast_dash.mcp import enable_mcp, warn_if_exposed
 
+            warn_if_exposed(kwargs)
             # Native Dash MCP mounts on this app at /mcp (shared port).
             enable_mcp(self)
         self.app.run(debug=debug, port=port, **kwargs)

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -289,7 +289,7 @@ class FastDash(ChatAppMixin):
         minimal=False,
         disable_logs=False,
         scale_height=1,
-        run_kwargs=dict(),
+        run_kwargs=None,
         tab_titles=None,
         steps=None,
         chat=False,
@@ -404,14 +404,8 @@ class FastDash(ChatAppMixin):
         if self.mcp_server_enabled:
             from .mcp import MCPState
             self._mcp_state = MCPState()
-            if mcp_host not in ("127.0.0.1", "localhost"):
-                warnings.warn(
-                    f"mcp_host={mcp_host!r} binds the MCP port to a non-loopback "
-                    "address. The MCP port has no authentication; anyone who "
-                    "can reach it can invoke your callback. Use 127.0.0.1 unless "
-                    "you have a deliberate reason to expose it.",
-                    stacklevel=2,
-                )
+            # The exposure warning lives in run(), keyed off the host we
+            # actually bind to -- see mcp.warn_if_exposed (#149).
 
         # callback_fn is required unless steps= is provided, or chat= itself
         # supplies the chat handler (an agent / graph / model / chat callable).
@@ -617,7 +611,11 @@ class FastDash(ChatAppMixin):
         self.disable_logs = disable_logs
         self.scale_height = scale_height
         self.port = port
-        self.run_kwargs = run_kwargs
+        # Copy, never alias: `run_kwargs` used to default to a shared mutable
+        # dict, so every app that didn't pass one aliased *the same* dict and the
+        # last constructed app silently rewrote every earlier app's port (and any
+        # other run_kwargs, including the security-relevant `host`) — #153.
+        self.run_kwargs = dict(run_kwargs) if run_kwargs else {}
         self.run_kwargs.update(dict(port=port))
         self.kwargs = kwargs
 
@@ -771,6 +769,12 @@ class FastDash(ChatAppMixin):
             if inputs is None
             else inputs if isinstance(inputs, list) else [inputs]
         )
+        # Whether the return annotation was used to build the outputs. When the
+        # caller passed `outputs=` explicitly it wins over the annotation, and the
+        # agent contract must describe what was actually rendered, not what the
+        # hint said (an `outputs=[Graph]` app whose callback is annotated `-> str`
+        # renders a figure, and must not tell an agent it returns a string).
+        self._outputs_inferred = outputs is None
         self.outputs = _infer_output_components(
             callback_fn, outputs, self.output_labels
         )
@@ -1377,7 +1381,11 @@ class FastDash(ChatAppMixin):
         """
         import uvicorn
 
-        host = self.run_kwargs.get("host", "127.0.0.1")
+        from .mcp import effective_bind_host
+
+        # Same host resolution Dash's own run() uses (run_kwargs, else $HOST,
+        # else loopback), so the address we bind is the address we warned about.
+        host = effective_bind_host(self.run_kwargs)
         port = self.run_kwargs.get("port", self.port)
         uvicorn.Server(
             uvicorn.Config(self.app.server, host=host, port=port, log_level="warning")
@@ -1398,7 +1406,12 @@ class FastDash(ChatAppMixin):
                 stacklevel=2,
             )
             return
-        from .mcp import enable_mcp
+        from .mcp import enable_mcp, warn_if_exposed
+
+        # Only warn about an exposed /mcp once we know we are about to mount one
+        # -- the multi-function bail-out above means mcp_server=True does not
+        # always produce an endpoint to expose (#149).
+        warn_if_exposed(self.run_kwargs)
 
         # Native Dash MCP shares the web app's host/port; agents connect at
         # http://<host>:<port>/mcp. The legacy mcp_port/mcp_host kwargs are
@@ -2606,7 +2619,7 @@ def fastdash(
     minimal=False,
     disable_logs=False,
     scale_height=1,
-    run_kwargs=dict(),
+    run_kwargs=None,
     chat=False,
     chat_history_size=50,
     chat_tools=None,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -60,11 +60,48 @@ from __future__ import annotations
 import collections
 import datetime
 import inspect
+import os
 import time
+import warnings
 from typing import Any
 
 # Holder kept for backwards compatibility with older imports/tests.
 _active_mcp_thread = None
+
+# Addresses that keep the (unauthenticated) /mcp route on this machine.
+LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
+
+
+def effective_bind_host(run_kwargs: dict | None) -> str:
+    """The address the server will actually bind to.
+
+    Mirrors Dash's own default (``HOST`` env var, else loopback), so callers
+    see the same host the dev server will use.
+    """
+    host = (run_kwargs or {}).get("host")
+    return host or os.getenv("HOST") or "127.0.0.1"
+
+
+def warn_if_exposed(run_kwargs: dict | None, *, stacklevel: int = 3) -> None:
+    """Warn when MCP is enabled on a socket reachable from off-box.
+
+    The MCP route is mounted on the Dash app itself, so what decides who can
+    reach it is the *server's* bind address -- ``run_kwargs["host"]`` (or the
+    ``HOST`` env var). The legacy ``mcp_host`` kwarg has not bound anything
+    since MCP moved onto the shared port, so warning on it gave a false
+    all-clear to ``mcp_server=True, run_kwargs={"host": "0.0.0.0"}`` -- the one
+    configuration that actually exposes an unauthenticated tool endpoint (#149).
+    """
+    host = effective_bind_host(run_kwargs)
+    if host in LOOPBACK_HOSTS:
+        return
+    warnings.warn(
+        f"mcp_server=True with host={host!r} serves the /mcp endpoint on a "
+        "non-loopback address. That endpoint has no authentication: anyone who "
+        "can reach this port can read your app's state and invoke your callback. "
+        "Bind to 127.0.0.1 unless you have put an authenticating proxy in front.",
+        stacklevel=stacklevel,
+    )
 
 
 class MCPState:
@@ -88,11 +125,40 @@ class MCPState:
         self.pending_inputs: dict[str, Any] = {}
         self.pending_specs: list[dict] | None = None
         self.pending_outputs: dict[str, Any] = {}
-        # The last form a set_form built. Unlike pending_specs (popped by the
-        # browser drain), this persists so describe_app can report the
-        # agent-generated form's contract — even after a browser renders it or
-        # a different agent reconnects.
+        # The form currently on screen (DynamicDash). Unlike pending_specs
+        # (popped by the browser drain), this persists so describe_app can report
+        # the form's contract — even after a browser renders it or a different
+        # agent reconnects. Always write it through set_current_specs.
         self.current_specs: list[dict] | None = None
+        # Every field ever declared a PasswordInput on this app. Accumulates and
+        # never shrinks: a credential that was in the mirror must stay masked
+        # even after the form that declared it is replaced.
+        self.secret_ids: set = set()
+
+    def set_current_specs(self, specs, keep=()) -> None:
+        """Point the contract at the form that is now on screen.
+
+        *Every* path that builds or replaces a DynamicDash form must call this —
+        ``initial_specs``, a ``parent_control`` cascade, and an agent's
+        ``set_form`` alike. The contract, the validators and the secret list are
+        all derived from it, so a form the agent didn't build itself would
+        otherwise have no contract at all: no ids to check, no options to
+        enforce, no secrets to mask.
+
+        Values belonging to fields the new form doesn't have are dropped, or
+        describe_app would go on reporting them (in the clear, if one of them was
+        a password) and ``invoke`` would go on passing them to the callback.
+        """
+        self.current_specs = [s for s in (specs or []) if isinstance(s, dict)]
+        live = {s.get("name") for s in self.current_specs}
+        live.update(keep)
+        self.secret_ids.update(
+            s["name"] for s in self.current_specs
+            if s.get("type") == "PasswordInput" and s.get("name")
+        )
+        for key in [k for k in self.inputs if k not in live]:
+            del self.inputs[key]
+            self.pending_inputs.pop(key, None)
 
     def append_history(self, entry_summary: dict, entry_full: dict) -> int:
         self.history.append(entry_summary)
@@ -336,6 +402,160 @@ def _component_bounds(comp):
     return props
 
 
+# What an agent sees instead of a secret's value. Not a valid value for any
+# widget, so a round-trip of describe_app -> set_input can't silently re-send it.
+REDACTED = "********"
+
+
+def _is_password_component(comp) -> bool:
+    return type(getattr(comp, "component", comp)).__name__ == "PasswordInput"
+
+
+def _secret_ids(fd, state=None) -> set:
+    """Ids whose value must never be echoed back over MCP.
+
+    A PasswordInput is the one widget whose value the browser deliberately
+    masks. Echoing it in ``describe_app`` / ``get_invocation`` would turn the
+    unauthenticated /mcp route into a plaintext read-out of a credential the UI
+    hides (#151), so the value goes in but never comes back out.
+
+    Static apps declare their inputs up front. A DynamicDash's fields come and
+    go, so its secrets are read from ``state.secret_ids``, which accumulates
+    every field ever declared a PasswordInput — including one whose form has
+    since been replaced, whose value would otherwise fall out of the contract's
+    mask and into describe_app's plain-mirror tail.
+    """
+    ids = set()
+    for c in (getattr(fd, "inputs_with_ids", None) or []):
+        if _is_password_component(c) or getattr(c, "tag", None) == "PasswordInput":
+            ids.add(_stringify_id(c.id))
+    parent = getattr(fd, "parent_control", None)
+    if isinstance(parent, dict) and parent.get("type") == "PasswordInput" and parent.get("name"):
+        ids.add(parent["name"])
+    if state is not None:
+        ids.update(getattr(state, "secret_ids", None) or set())
+    return ids
+
+
+def _redact(entry, value):
+    """The value ``entry`` may reveal: itself, or a mask for a secret input."""
+    if not entry.get("secret"):
+        return value
+    return REDACTED if value not in (None, "") else value
+
+
+def _redact_props(entry, props):
+    """Props minus anything that carries the widget's value.
+
+    ``default`` and ``current_value`` are masked for a secret input, but a spec
+    is free to carry its value in ``props`` (``_describe_dynamic_inputs`` reads
+    ``props["value"]`` as a fallback default) — and props were echoed verbatim,
+    so the credential rode out in a sibling field of the very entry stamped
+    ``"secret": true``.
+    """
+    if not entry.get("secret") or not isinstance(props, dict):
+        return props
+    return {k: v for k, v in props.items() if k not in ("value", "defaultValue")}
+
+
+def _normalize_options(options):
+    """Flatten dropdown options to the plain values a widget can emit.
+
+    A DynamicDash ``Select``/``MultiSelect`` may declare its ``data`` as
+    ``[{"label": ..., "value": ...}, ...]``; only the ``value`` half is ever
+    emitted, so that is what membership must be checked against.
+    """
+    if not isinstance(options, (list, tuple)):
+        return None
+    out = []
+    for o in options:
+        out.append(o["value"] if isinstance(o, dict) and "value" in o else o)
+    return out
+
+
+def _type_error(entry, value):
+    """Reject a value whose JSON type the widget could never emit, else None.
+
+    The bounds check below only fires for numbers, so before #150 a *string*
+    sailed past a Slider's ``min``/``max`` untouched (``"9999"`` is not an
+    ``int``, so nothing compared it to the maximum) and reached the callback as
+    a string — a value no drag of the slider could produce. Types with more than
+    one legal wire shape (dates, uploads, and anything with ``options``, which
+    is membership-checked instead) stay permissive.
+    """
+    jtype = entry.get("type")
+    if jtype in ("integer", "number"):
+        # bool is an int subclass in Python; a Switch value is not a number.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            article = "an" if jtype == "integer" else "a"
+            return f"expected {article} {jtype}, got {type(value).__name__} ({value!r})"
+        if jtype == "integer" and isinstance(value, float) and not value.is_integer():
+            return f"expected an integer, got {value!r}"
+    elif jtype == "boolean" and not isinstance(value, bool):
+        return f"expected a boolean, got {type(value).__name__} ({value!r})"
+    return None
+
+
+def _describe_dynamic_inputs(fd, snapshot, specs, state=None):
+    """Per-input contract for a DynamicDash form, whoever built it.
+
+    Same shape as the static contract, derived from the live specs instead of a
+    callback signature — so the options and bounds the form declares are the ones
+    ``set_input`` / ``invoke`` then enforce against it (#144), whether those
+    specs came from ``initial_specs``, a ``parent_control`` cascade, or an
+    agent's ``set_form``. The parent control is part of the contract too: the UI
+    passes it to the callback like any other field, so an agent must be able to
+    discover and drive it.
+    """
+    from fast_dash.utils import _jsonify_for_mcp
+
+    secrets = _secret_ids(fd, state)
+    parent = getattr(fd, "parent_control", None)
+    all_specs = list(specs)
+    if isinstance(parent, dict) and parent.get("name"):
+        all_specs = [parent] + all_specs
+
+    contract = []
+    for spec in all_specs:
+        name = spec.get("name")
+        if not name:
+            continue
+        props = spec.get("props") or {}
+        default = spec.get("value", props.get("value"))
+        cur = snapshot.get(name, default)
+        entry = {
+            "id": name,
+            # tag = the DynamicDash component name (e.g. "Slider"); type = its
+            # JSON type, so ``type`` means the same thing here as on a static
+            # app's contract (issue #131).
+            "tag": spec.get("type"),
+            "type": _spec_json_type(spec.get("type")),
+            "label": spec.get("label"),
+            "options": _jsonify_for_mcp(_normalize_options(props.get("data"))),
+            "secret": name in secrets,
+        }
+        entry["props"] = _jsonify_for_mcp(_redact_props(entry, props))
+        entry["default"] = _jsonify_for_mcp(_redact(entry, default))
+        entry["current_value"] = _jsonify_for_mcp(_redact(entry, cur))
+        contract.append(entry)
+    return contract
+
+
+def _input_contract(fd, snapshot, state=None):
+    """The app's input contract, static or dynamic — one source of truth.
+
+    ``describe_app`` reports it and the validators enforce it, so an agent can
+    never set a value the app doesn't advertise, whichever kind of app it is.
+    """
+    if _enumerate_inputs(fd):
+        return _describe_static_inputs(fd, snapshot)
+    state = state if state is not None else getattr(fd, "_mcp_state", None)
+    specs = getattr(state, "current_specs", None) if state is not None else None
+    if specs or (specs is not None and getattr(fd, "parent_control", None)):
+        return _describe_dynamic_inputs(fd, snapshot, specs or [], state)
+    return []
+
+
 def _describe_static_inputs(fd, snapshot):
     """Per-input contract for a static FastDash app.
 
@@ -368,6 +588,7 @@ def _describe_static_inputs(fd, snapshot):
     except Exception:
         hints = {}
 
+    secrets = _secret_ids(fd)
     contract = []
     for d in descriptors:
         cid = d["id"]
@@ -415,10 +636,11 @@ def _describe_static_inputs(fd, snapshot):
             "id": cid,
             "tag": d["tag"],
             "type": jtype,
-            "default": _jsonify_for_mcp(default),
             "options": _jsonify_for_mcp(options),
-            "current_value": _jsonify_for_mcp(cur),
+            "secret": cid in secrets,          # PasswordInput: value never echoed (#151)
         }
+        entry["default"] = _jsonify_for_mcp(_redact(entry, default))
+        entry["current_value"] = _jsonify_for_mcp(_redact(entry, cur))
         bounds = _component_bounds(components.get(cid))
         if bounds:
             entry["props"] = bounds                   # Slider min/max/step (issue #120)
@@ -426,17 +648,96 @@ def _describe_static_inputs(fd, snapshot):
     return contract
 
 
-def _option_error(fd, component_id, value, snapshot):
+# (tag, JSON type) per rendered output component. An output's Python annotation
+# is often a rich object (``go.Figure``, ``pd.DataFrame``, ``PIL.Image``) with no
+# JSON scalar equivalent, so the component it was rendered into is the honest
+# description of what an agent gets back from ``invoke``.
+_OUTPUT_KIND = {
+    "Graph": ("Graph", "object"),
+    "DataTable": ("Table", "array"),
+    "Markdown": ("Markdown", "string"),
+    "Textarea": ("Text", "string"),
+    "TextInput": ("Text", "string"),
+    "H1": ("Text", "string"),
+    "Div": ("Text", "string"),
+    "Img": ("Image", "string"),
+    "Download": ("Download", "string"),
+}
+
+
+def _output_kind(comp):
+    """(tag, JSON type) for one output component.
+
+    ``FastComponent.tag`` is unusable here: an inferred ``-> str`` output carries
+    the raw annotation *object* (``<class 'str'>``) and an explicit ``Table``
+    carries ``None``. Nothing serialized it before #152, so nobody noticed. The
+    rendered component is always present and always honest.
+    """
+    name = type(getattr(comp, "component", comp)).__name__
+    return _OUTPUT_KIND.get(name, (name, "object"))
+
+
+def _describe_outputs(fd, state=None):
+    """Per-output contract: what ``invoke`` will produce, without running it.
+
+    ``describe_app`` used to report inputs only, so the sole way for a headless
+    agent to learn what an app returns was to *call* it — discovery by side
+    effect (#152). Each entry is ``{id, tag, type, label}``, plus a summary of
+    the value currently on screen once something has run.
+    """
+    from fast_dash.Components import expand_return_annotation
+    from fast_dash.utils import _summarize_for_history
+
+    components = list(getattr(fd, "outputs_with_ids", None) or [])
+    anns = []
+    # Only consult the annotation when the outputs were built *from* it. An
+    # explicit `outputs=[Graph]` wins over a `-> str` hint, and the contract has
+    # to describe the figure that is really rendered.
+    if getattr(fd, "_outputs_inferred", True):
+        try:
+            import typing
+            ret = typing.get_type_hints(fd.callback_fn).get("return")
+        except Exception:
+            ret = inspect.signature(fd.callback_fn).return_annotation
+        if ret is not None and ret is not inspect.Signature.empty:
+            anns = expand_return_annotation(ret)
+
+    outputs = []
+    for i, comp in enumerate(components):
+        tag, jtype = _output_kind(comp)
+        # A scalar annotation is more specific than the component (an int and a
+        # string both render as text) — prefer it when it maps to a JSON type.
+        if i < len(anns) and anns[i] in (str, int, float, bool, list, dict):
+            jtype = _json_type_name(anns[i])
+        cid = _stringify_id(comp.id)
+        entry = {"id": cid, "tag": tag, "type": jtype}
+        # label_ is the label the UI actually renders: _infer_output_components
+        # normalizes a wrong-length output_labels list to OUTPUT_1/OUTPUT_2 and
+        # stamps it on the component, while fd.output_labels keeps the original.
+        label = getattr(comp, "label_", None)
+        if label:
+            entry["label"] = label
+        if state is not None and cid in state.outputs:
+            entry["current_value"] = _summarize_for_history(state.outputs[cid])
+        outputs.append(entry)
+    return outputs
+
+
+def _option_error(fd, component_id, value, snapshot, state=None):
     """Reject a value the UI could never produce, else None.
 
     Validates against the very contract ``describe_app`` reports (parity), so an
     agent can never set a value the UI widget couldn't: a value outside a
-    dropdown's ``options`` (issue #116) or outside a Slider's ``min``/``max``
-    bounds (issue #120). Permissive by design: an input with neither advertised
-    options nor bounds accepts any value, and ``None`` always clears a
-    selection. For a MultiSelect (list value) every element must be a legal key.
+    dropdown's ``options`` (issue #116), of the wrong JSON ``type`` (issue
+    #150), or outside a Slider's ``min``/``max`` bounds (issue #120). The
+    contract comes from :func:`_input_contract`, so a DynamicDash form an agent
+    built with ``set_form`` is validated against *its own* declared options and
+    bounds rather than skipped (issue #144). Permissive by design: an input with
+    no advertised options, type or bounds accepts any value, and ``None`` always
+    clears a selection. For a MultiSelect (list value) every element must be a
+    legal key.
     """
-    for entry in _describe_static_inputs(fd, snapshot):
+    for entry in _input_contract(fd, snapshot, state):
         if entry["id"] != component_id:
             continue
         if value is None:
@@ -451,6 +752,9 @@ def _option_error(fd, component_id, value, snapshot):
             if value not in options:
                 return f"value {value!r} not in allowed options {options}"
             return None
+        bad_type = _type_error(entry, value)
+        if bad_type:
+            return bad_type
         # Numeric Slider bounds (no options): reject out-of-range, like the UI.
         props = entry.get("props") or {}
         lo, hi = props.get("min"), props.get("max")
@@ -610,25 +914,39 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
 
     # ----- fast_dash value-add tools (stateful: drive the live app) --------- #
 
+    def _contract_index(snapshot):
+        """{id: entry} for whichever contract this app has (static or set_form).
+
+        Keying the guards off this instead of ``_enumerate_inputs`` is what lets
+        a DynamicDash form -- which has no static inputs at all -- be validated
+        against the specs the agent itself declared (#144).
+        """
+        return {e["id"]: e for e in _input_contract(fd, snapshot, state)}
+
+    def _echo(entries, cid, value):
+        """The value to report back: masked for a PasswordInput (#151)."""
+        return _jsonify_for_mcp(_redact(entries.get(cid) or {}, value))
+
     @mcp_enabled(name="set_input", expose_docstring=True)
     def set_input(component_id: str, value: Any) -> dict:
         """Update one input's value, server-side and live in the browser.
 
         Browser update lands within ~500ms (Dash ``Interval`` drain).
         """
-        ids = {d["id"] for d in _enumerate_inputs(fd)}
-        if ids and component_id not in ids:
+        snapshot = dict(state.inputs)
+        entries = _contract_index(snapshot)
+        if entries and component_id not in entries:
             return {
                 "ok": False,
                 "error": f"Unknown input id {component_id!r}",
-                "known_ids": sorted(ids),
+                "known_ids": sorted(entries),
             }
-        bad = _option_error(fd, component_id, value, dict(state.inputs))
+        bad = _option_error(fd, component_id, value, snapshot, state)
         if bad:
             return {"ok": False, "error": bad, "id": component_id}
         state.inputs[component_id] = value
         state.pending_inputs[component_id] = value
-        return {"ok": True, "id": component_id, "value": _jsonify_for_mcp(value)}
+        return {"ok": True, "id": component_id, "value": _echo(entries, component_id, value)}
 
     @mcp_enabled(name="set_inputs", expose_docstring=True)
     def set_inputs(inputs: dict) -> dict:
@@ -636,21 +954,21 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
 
         The argument is named ``inputs`` to match ``invoke(inputs=...)``.
         """
-        ids = {d["id"] for d in _enumerate_inputs(fd)}
         snapshot = dict(state.inputs)
+        entries = _contract_index(snapshot)
         applied, errors = {}, {}
         for k, v in (inputs or {}).items():
-            if ids and k not in ids:
+            if entries and k not in entries:
                 errors[k] = "unknown id"
                 continue
-            bad = _option_error(fd, k, v, snapshot)
+            bad = _option_error(fd, k, v, snapshot, state)
             if bad:
                 errors[k] = bad
                 continue
             state.inputs[k] = v
             state.pending_inputs[k] = v
             snapshot[k] = v
-            applied[k] = _jsonify_for_mcp(v)
+            applied[k] = _echo(entries, k, v)
         return {"ok": not errors, "applied": applied, "errors": errors}
 
     @mcp_enabled(name="invoke", expose_docstring=True)
@@ -667,21 +985,21 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             }
 
         if inputs:
-            ids = {d["id"] for d in _enumerate_inputs(fd)}
-            if ids:
-                unknown = sorted(k for k in inputs if k not in ids)
+            snapshot = dict(state.inputs)
+            entries = _contract_index(snapshot)
+            if entries:
+                unknown = sorted(k for k in inputs if k not in entries)
                 if unknown:
                     return {
                         "ok": False,
                         "error": f"unknown input id(s): {unknown}",
-                        "known_ids": sorted(ids),
+                        "known_ids": sorted(entries),
                     }
             # Validate against advertised options before mutating (atomic: a
             # bad value rejects the whole call without touching the mirror).
-            snapshot = dict(state.inputs)
             option_errors = {}
             for k, v in inputs.items():
-                bad = _option_error(fd, k, v, snapshot)
+                bad = _option_error(fd, k, v, snapshot, state)
                 if bad:
                     option_errors[k] = bad
                 else:
@@ -706,6 +1024,21 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         else:
             kwargs = dict(snapshot)
 
+        # Secrets go into the callback but never come back out — not in the
+        # error echo, and not in the history a later get_invocation reads (#151).
+        entries = _contract_index(snapshot)
+
+        def _kwargs_summary():
+            out = {}
+            for k, v in kwargs.items():
+                entry = entries.get(k) or entries.get(f"input_{k}") or {}
+                out[k] = (
+                    REDACTED
+                    if entry.get("secret") and v not in (None, "")
+                    else _summarize_for_history(v)
+                )
+            return out
+
         t0 = time.time()
         try:
             result = fd.callback_fn(**kwargs)
@@ -713,9 +1046,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             return {
                 "ok": False,
                 "error": f"{type(e).__name__}: {e}",
-                "kwargs_summary": {
-                    k: _summarize_for_history(v) for k, v in kwargs.items()
-                },
+                "kwargs_summary": _kwargs_summary(),
             }
         dt_ms = round((time.time() - t0) * 1000, 1)
 
@@ -729,7 +1060,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         entry_summary = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
             "duration_ms": dt_ms,
-            "kwargs": {k: _summarize_for_history(v) for k, v in kwargs.items()},
+            "kwargs": _kwargs_summary(),
             "outputs": out_summary,
         }
         entry_full = {**entry_summary, "_full_kwargs": kwargs, "_full_result": result}
@@ -761,8 +1092,11 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
                 return {"ok": False, "error": f"invalid spec: {e}", "spec": spec}
         state.pending_specs = specs
         # Keep a persistent copy so describe_app can report the form contract
-        # (pending_specs is popped by the browser drain).
-        state.current_specs = specs
+        # (pending_specs is popped by the browser drain), and drop mirror values
+        # for fields this form no longer has — the parent control survives, it
+        # isn't part of the form.
+        parent = getattr(fd, "parent_control", None) or {}
+        state.set_current_specs(specs, keep={parent.get("name")} - {None})
         return {"ok": True, "count": len(specs)}
 
     @mcp_enabled(name="get_invocation", expose_docstring=True)
@@ -790,65 +1124,44 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
 
     @mcp_enabled(name="describe_app", expose_docstring=True)
     def describe_app() -> dict:
-        """Describe the app's inputs: id, type, default, options, and CURRENT value.
+        """Describe the app's inputs and outputs, plus their CURRENT values.
 
         This is the reliable way for a headless agent (no browser) to read the
-        app's input contract *and* its live state before calling ``invoke``:
-        each input reports its parameter ``id``, JSON ``type``, ``default``,
-        any allowed ``options`` (for dropdowns / ``Literal`` / ``Enum``), and
-        its ``current_value`` — including values you set via ``set_input`` /
-        ``set_inputs``. (The native ``dash://components`` resource lists ids and
-        Dash *widget* types only, and ``get_dash_component`` reflects the
-        browser, not the agent's mirror, so neither shows agent-set values
-        headlessly.)
+        app's contract *and* its live state before calling ``invoke``: each
+        input reports its parameter ``id``, JSON ``type``, ``default``, any
+        allowed ``options`` (for dropdowns / ``Literal`` / ``Enum``), and its
+        ``current_value`` — including values you set via ``set_input`` /
+        ``set_inputs``. Each output reports its ``id``, the component ``tag`` it
+        renders into, its JSON ``type`` and ``label``, so you can see what a run
+        will produce without having to run it. (The native ``dash://components``
+        resource lists ids and Dash *widget* types only, and
+        ``get_dash_component`` reflects the browser, not the agent's mirror, so
+        neither shows agent-set values headlessly.)
         """
         snapshot = dict(state.inputs)
-        descriptors = _enumerate_inputs(fd)
-
-        inputs = []
-        if descriptors:
-            inputs = _describe_static_inputs(fd, snapshot)
-        elif state.current_specs:
-            # DynamicDash: report the agent-built form's contract from the specs
-            # set_form materialized, merged with any current values.
-            seen = set()
-            for spec in state.current_specs:
-                name = spec.get("name")
-                if not name:
-                    continue
-                seen.add(name)
-                props = spec.get("props") or {}
-                # Slider/number bounds, Select/MultiSelect options, etc. live in
-                # props; expose them so the contract is fully discoverable.
-                options = props.get("data")
-                default = spec.get("value", props.get("value"))
-                cur = snapshot.get(name, default)
-                inputs.append({
-                    "id": name,
-                    # tag = the DynamicDash component name (e.g. "Slider");
-                    # type = its JSON type, so ``type`` means the same thing here
-                    # as on a static app's contract (issue #131).
-                    "tag": spec.get("type"),
-                    "type": _spec_json_type(spec.get("type")),
-                    "label": spec.get("label"),
-                    "default": _jsonify_for_mcp(default),
-                    "options": _jsonify_for_mcp(options),
-                    "props": _jsonify_for_mcp(props),
-                    "current_value": _jsonify_for_mcp(cur),
-                })
-            # Any extra mirror keys not in the form (defensive).
-            for k, v in snapshot.items():
-                if k not in seen:
-                    inputs.append({"id": k, "current_value": _jsonify_for_mcp(v)})
-        else:
-            # No form built yet — reflect whatever the mirror holds.
-            for k, v in snapshot.items():
-                inputs.append({"id": k, "current_value": _jsonify_for_mcp(v)})
+        # The same contract the validators enforce — static signature, or the
+        # form an agent built with set_form (#144).
+        inputs = _input_contract(fd, snapshot, state)
+        seen = {e["id"] for e in inputs}
+        # Any extra mirror keys not in the contract (defensive; also the only
+        # thing to report on a DynamicDash app with no form built yet). These
+        # have no contract entry to carry a "secret" flag, so consult the
+        # persistent secret list directly — a value that fell out of the contract
+        # must not fall out of the mask with it.
+        secrets = _secret_ids(fd, state)
+        for k, v in snapshot.items():
+            if k not in seen:
+                entry = {"id": k, "secret": k in secrets}
+                entry["current_value"] = _jsonify_for_mcp(_redact(entry, v))
+                inputs.append(entry)
 
         return {
             "title": getattr(fd, "title", None) or "",
             "doc": (getattr(fd.callback_fn, "__doc__", "") or "").strip(),
             "inputs": inputs,
+            # What a run produces — discoverable without side-effectingly
+            # calling invoke() to find out (#152).
+            "outputs": _describe_outputs(fd, state),
         }
 
     # Mount the MCP routes on the Dash app (same port).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.6.2"
+version = "0.6.3"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/_pil_hint_app.py
+++ b/tests/_pil_hint_app.py
@@ -1,0 +1,16 @@
+"""PEP-563 module returning a PIL image via the loose `-> Image` spelling (#156).
+
+`from PIL import Image` binds a *module* to the name, and the output inference
+has a by-name fallback for exactly this spelling. Resolving the annotation
+string must not hand that fallback a module object — a returned picture would
+render as an <h1>.
+"""
+
+from __future__ import annotations
+
+from PIL import Image
+
+
+def make_thumb(size: int = 64) -> Image:
+    """Solid square thumbnail."""
+    return Image.new("RGB", (size, size), "red")

--- a/tests/_tuple_hint_app.py
+++ b/tests/_tuple_hint_app.py
@@ -1,0 +1,18 @@
+"""A plain module using `from __future__ import annotations` (#156).
+
+Under future annotations every hint reaches fast_dash as a *string*, so a
+`Tuple[...]` return hint is not even recognizably a tuple until it's resolved.
+Lives in its own module because a function defined inside a test can't have its
+annotations resolved against that test's locals.
+"""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+import plotly.graph_objects as go
+
+
+def chart_and_caption(n: int = 3) -> Tuple[go.Figure, str]:
+    """Chart n bars and caption it."""
+    return go.Figure(go.Bar(x=list(range(n)), y=list(range(n)))), f"{n} bars"

--- a/tests/test_dynamic.py
+++ b/tests/test_dynamic.py
@@ -234,15 +234,25 @@ def test_dynamicdash_run_skips_mcp_when_disabled(monkeypatch):
     assert called["enabled"] is False
 
 
-def test_dynamicdash_warns_on_non_loopback_mcp_host():
-    with pytest.warns(UserWarning, match="non-loopback"):
-        DynamicDash(
-            callback_fn=lambda x=1: x,
-            initial_specs=[{"name": "x", "type": "Text"}],
-            output_components=[Markdown],
-            mcp_server=True,
-            mcp_host="0.0.0.0",
-        )
+def test_dynamicdash_warns_when_serving_mcp_off_loopback(monkeypatch):
+    # #149: the warning must key off the host the server actually binds
+    # (run's host=), not the legacy mcp_host kwarg, which stopped binding
+    # anything when MCP moved onto the app's own port. Warning on mcp_host gave
+    # a false all-clear to exactly the setup that exposes an unauthenticated
+    # tool endpoint: mcp_server=True served on 0.0.0.0.
+    app = DynamicDash(
+        callback_fn=lambda x=1: x,
+        initial_specs=[{"name": "x", "type": "Text"}],
+        output_components=[Markdown],
+        mcp_server=True,
+        mcp_host="0.0.0.0",           # binds nothing -> not the thing to warn on
+    )
+    monkeypatch.setattr(app.app, "run", lambda **kw: None)
+    # Don't actually mount MCP: registration writes to Dash's process-global
+    # tool registry, which the tests in test_mcp.py own.
+    monkeypatch.setattr("fast_dash.mcp.enable_mcp", lambda fd, **kw: None)
+    with pytest.warns(UserWarning, match="no authentication"):
+        app.run(host="0.0.0.0")
 
 
 def test_dynamicdash_placeholder_builds_hint_spec():

--- a/tests/test_fast_dash.py
+++ b/tests/test_fast_dash.py
@@ -421,3 +421,27 @@ def test_fdfd016_stream_text_simple(dash_duo):
     # Now assert on the final text
     final_text = dash_duo.find_element("#output_output_text").text
     assert "output" in final_text
+
+def test_run_kwargs_are_not_shared_between_apps():
+    """Two apps must not share one run_kwargs dict (#153).
+
+    `run_kwargs=dict()` was a mutable default, so every app that didn't pass one
+    aliased *the same* dict — and the constructor then mutated it with its own
+    port. Building a second app silently rewrote the first app's port (and any
+    other run_kwargs, including the security-relevant `host`).
+    """
+    a = FastDash(callback_fn=simple_text_to_text_function, port=8001)
+    b = FastDash(callback_fn=simple_text_to_text_function, port=8002)
+
+    assert a.run_kwargs is not b.run_kwargs
+    assert a.run_kwargs["port"] == 8001      # not clobbered by b's construction
+    assert b.run_kwargs["port"] == 8002
+
+
+def test_caller_run_kwargs_dict_is_not_mutated():
+    "The dict the caller passed stays the caller's — we copy before mutating (#153)."
+    shared = {"host": "0.0.0.0"}
+    app = FastDash(callback_fn=simple_text_to_text_function, port=8003, run_kwargs=shared)
+
+    assert shared == {"host": "0.0.0.0"}     # no port injected into the caller's dict
+    assert app.run_kwargs == {"host": "0.0.0.0", "port": 8003}

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -16,13 +16,14 @@ import datetime  # module-level so get_type_hints resolves date/datetime hints (
 import enum
 import importlib.util
 import json
-from typing import Annotated, Optional  # module-level for get_type_hints (#119, #132)
+import warnings
+from typing import Annotated, Optional, Tuple  # module-level for get_type_hints (#119, #132)
 
 import pandas as pd  # noqa: F401  (module-level for any -> pd.DataFrame hints)
 import plotly.graph_objects as go
 import pytest
 
-from fast_dash import DynamicDash, FastDash, Graph, Markdown
+from fast_dash import DynamicDash, FastDash, Graph, Markdown, PasswordInput
 from fast_dash.mcp import MCPState, enable_mcp
 
 
@@ -113,6 +114,14 @@ def _call(client, name, args=None):
     return r
 
 
+def _exposure_warnings(fn):
+    """The MCP no-auth warnings raised by ``fn`` (ignoring library noise)."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fn()
+    return [w for w in caught if "no authentication" in str(w.message)]
+
+
 def _plain_app():
     def plot_bars(n: int = 6, color: str = "#1c7ed6") -> go.Figure:
         """Bar chart with n bars."""
@@ -120,12 +129,13 @@ def _plain_app():
     return FastDash(callback_fn=plot_bars, mcp_server=True)
 
 
-def _dynamic_app():
+def _dynamic_app(**kw):
     def score(**fields):
         """Radar of submitted fields."""
         return go.Figure(), "ok"
+    kw.setdefault("placeholder", "hi")
     return DynamicDash(callback_fn=score, output_components=[Graph, Markdown],
-                       placeholder="hi", mcp_server=True)
+                       mcp_server=True, **kw)
 
 
 # --- MCPState -------------------------------------------------------------- #
@@ -605,6 +615,310 @@ class TestTools:
         out = _call(c, "set_form", {"specs": [{"name": "x", "type": "NotReal"}]})
         assert out["ok"] is False
         assert "Unknown component type" in out["error"]
+
+    def test_describe_app_reports_the_output_contract(self):
+        # #152: describe_app reported inputs only, so the one way for a headless
+        # agent to learn what an app returns was to *call* it — discovery by side
+        # effect. Outputs are now part of the contract.
+        def report(n: int = 3) -> Tuple[go.Figure, str]:
+            """Chart n and summarize it."""
+            return go.Figure(go.Bar(x=[n], y=[n])), f"{n} bars"
+
+        app = FastDash(callback_fn=report, mcp_server=True,
+                       output_labels=["Chart", "Summary"])
+        c = _client_for(app)
+
+        outs = _call(c, "describe_app")["outputs"]
+        assert [o["tag"] for o in outs] == ["Graph", "Text"]
+        assert [o["label"] for o in outs] == ["Chart", "Summary"]
+        assert [o["type"] for o in outs] == ["object", "string"]
+        # Nothing has run yet — no values claimed.
+        assert all("current_value" not in o for o in outs)
+
+        run = _call(c, "invoke", {"inputs": {"n": 4}})
+        assert run["ok"] is True
+        after = _call(c, "describe_app")["outputs"]
+        assert after[1]["current_value"] == "4 bars"   # live value, still typed
+
+    def test_str_hint_widgets_report_the_widget_they_became(self):
+        # #147: a colour picker, a textarea and a text box are three different
+        # widgets, but all three reported tag "Text" (the `str` hint), so a
+        # headless agent reading describe_app could not tell them apart — it had
+        # no way to know `color` wants a hex string the UI can actually render.
+        def style(color: str = "#1c7ed6",
+                  bio: str = "line one\nline two",
+                  name: str = "kedar") -> str:
+            """Style a profile."""
+            return f"{color}{bio}{name}"
+
+        c = _client_for(FastDash(callback_fn=style, mcp_server=True))
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert by_id["color"]["tag"] == "ColorInput"
+        assert by_id["bio"]["tag"] == "TextArea"
+        assert by_id["name"]["tag"] == "Text"
+
+    def test_password_value_goes_in_but_never_comes_back(self):
+        # #151: the browser masks a PasswordInput; the unauthenticated /mcp route
+        # must not undo that by reading the credential back out in plain text.
+        # (PasswordInput is imported at module level so get_type_hints can
+        # resolve this annotation under the file's future annotations — #119.)
+        def login(pwd: PasswordInput = "hunter2", user: str = "kedar") -> str:
+            """Log in."""
+            return f"{user}:{pwd}"
+
+        app = FastDash(callback_fn=login, mcp_server=True)
+        c = _client_for(app)
+
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert by_id["pwd"]["secret"] is True
+        assert by_id["pwd"]["default"] == "********"      # seeded default masked
+        assert by_id["user"]["secret"] is False
+        assert by_id["user"]["default"] == "kedar"        # non-secrets unchanged
+
+        # The value is settable (an agent must be able to fill it) but the echo
+        # is masked, and the mirror really did take the value.
+        out = _call(c, "set_input", {"component_id": "pwd", "value": "s3cret"})
+        assert out["ok"] is True and out["value"] == "********"
+        assert app._mcp_state.inputs["pwd"] == "s3cret"
+
+        cur = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert cur["pwd"]["current_value"] == "********"
+
+        # ...and it does not leak through invoke's history either.
+        run = _call(c, "invoke")
+        assert run["ok"] is True
+        hist = _call(c, "get_invocation", {"index": run["history_index"]})
+        assert hist["kwargs_summary"]["pwd"] == "********"
+        assert hist["kwargs_summary"]["user"] == "kedar"
+
+    def test_wrong_type_rejected_so_bounds_cannot_be_bypassed(self):
+        # #150: the bounds check only fires for numbers, so a *string* used to
+        # sail straight past a Slider's min/max ("9999" is not an int, so nothing
+        # compared it to the maximum) and reach the callback as a value no drag
+        # of the slider could produce.
+        from tests._slider_app import slider_demo
+
+        app = FastDash(callback_fn=slider_demo, mcp_server=True)
+        c = _client_for(app)
+
+        bad = _call(c, "set_input", {"component_id": "via_annot", "value": "9999"})
+        assert bad["ok"] is False and "expected an integer" in bad["error"]
+        assert "via_annot" not in app._mcp_state.pending_inputs
+        # ...including the unbounded number box, which has a type but no range.
+        bad2 = _call(c, "set_input", {"component_id": "plain_num", "value": "lots"})
+        assert bad2["ok"] is False and "expected an integer" in bad2["error"]
+        # Numbers still pass.
+        assert _call(c, "set_input", {"component_id": "via_annot", "value": 42})["ok"]
+
+    def test_boolean_input_rejects_non_boolean(self):
+        # #150: a Switch can only ever emit True/False.
+        def flag(on: bool = False, note: str = "") -> str:
+            """Toggle."""
+            return f"{on}{note}"
+
+        c = _client_for(FastDash(callback_fn=flag, mcp_server=True))
+        bad = _call(c, "set_input", {"component_id": "on", "value": "yes"})
+        assert bad["ok"] is False and "expected a boolean" in bad["error"]
+        assert _call(c, "set_input", {"component_id": "on", "value": True})["ok"]
+        # A free-text input stays permissive — nothing is advertised about it.
+        assert _call(c, "set_input", {"component_id": "note", "value": "anything"})["ok"]
+
+    def test_agent_built_form_is_validated_against_its_own_specs(self):
+        # #144: DynamicDash has no static inputs, so every guard keyed off
+        # _enumerate_inputs short-circuited and an agent-built form skipped ALL
+        # validation — unknown ids, out-of-options and out-of-range values all
+        # landed in the mirror. The specs the agent declared ARE the contract.
+        app = _dynamic_app()
+        c = _client_for(app)
+        _call(c, "set_form", {"specs": [
+            {"name": "skill", "type": "Slider", "props": {"min": 0, "max": 10}},
+            {"name": "team", "type": "Select",
+             "props": {"data": ["red", "blue"]}},
+        ]})
+
+        unknown = _call(c, "set_input", {"component_id": "nope", "value": 1})
+        assert unknown["ok"] is False and unknown["known_ids"] == ["skill", "team"]
+
+        hi = _call(c, "set_input", {"component_id": "skill", "value": 99})
+        assert hi["ok"] is False and "maximum" in hi["error"]
+
+        off = _call(c, "set_input", {"component_id": "team", "value": "green"})
+        assert off["ok"] is False and "allowed options" in off["error"]
+
+        # Nothing invalid reached the mirror; valid values still do.
+        assert app._mcp_state.inputs.get("skill") is None
+        assert _call(c, "set_input", {"component_id": "skill", "value": 7})["ok"]
+        assert _call(c, "set_input", {"component_id": "team", "value": "red"})["ok"]
+        assert app._mcp_state.inputs["skill"] == 7
+
+    def test_agent_built_select_accepts_label_value_options(self):
+        # A DynamicDash Select may declare data as [{label, value}, ...]; only the
+        # value half is ever emitted, so that is what membership checks.
+        app = _dynamic_app()
+        c = _client_for(app)
+        _call(c, "set_form", {"specs": [
+            {"name": "team", "type": "Select", "props": {
+                "data": [{"label": "Red team", "value": "red"},
+                         {"label": "Blue team", "value": "blue"}]}},
+        ]})
+        assert _call(c, "set_input", {"component_id": "team", "value": "red"})["ok"]
+        bad = _call(c, "set_input", {"component_id": "team", "value": "Red team"})
+        assert bad["ok"] is False and "allowed options" in bad["error"]
+
+
+class TestSecretsNeverLeave:
+    """#151, hardened: the secret must not appear ANYWHERE in a payload.
+
+    Asserting that `current_value` is masked is not the same as asserting the
+    credential didn't ride out in a sibling field — `props`, the plain-mirror
+    tail of describe_app, an error string. These tests search the serialized
+    payload for the string itself, which is the only assertion that can't be
+    satisfied by masking the one field the author happened to think of.
+    """
+
+    SECRET = "sk-live-DO-NOT-LEAK"
+
+    def _assert_clean(self, payload):
+        assert self.SECRET not in json.dumps(payload, default=str)
+
+    def test_app_authored_dynamic_password_is_masked(self):
+        # An `initial_specs` form is authored by the app, not the agent — so its
+        # PasswordInput was invisible to a secret list built from set_form specs.
+        app = _dynamic_app(placeholder=None, initial_specs=[
+            {"name": "api_key", "type": "PasswordInput"},
+            {"name": "q", "type": "Text"},
+        ])
+        c = _client_for(app)
+        assert _call(c, "set_input", {"component_id": "api_key", "value": self.SECRET})["ok"]
+
+        self._assert_clean(_call(c, "describe_app"))
+        run = _call(c, "invoke")
+        self._assert_clean(run)
+        self._assert_clean(_call(c, "get_invocation", {"index": run["history_index"]}))
+        # ...but the callback really did receive it.
+        assert app._mcp_state.inputs["api_key"] == self.SECRET
+
+    def test_secret_in_spec_props_is_masked(self):
+        # A spec may carry its value in props; props were echoed verbatim, so the
+        # credential rode out beside the very entry stamped "secret": true.
+        app = _dynamic_app()
+        c = _client_for(app)
+        _call(c, "set_form", {"specs": [
+            {"name": "api_key", "type": "PasswordInput",
+             "props": {"value": self.SECRET}},
+        ]})
+        desc = _call(c, "describe_app")
+        entry = desc["inputs"][0]
+        assert entry["secret"] is True and entry["current_value"] == "********"
+        self._assert_clean(desc)
+
+    def test_secret_survives_a_form_swap(self):
+        # Replacing the form must not strand the old password's value in the
+        # mirror, where describe_app's plain tail would print it in the clear.
+        app = _dynamic_app()
+        c = _client_for(app)
+        _call(c, "set_form", {"specs": [
+            {"name": "api_key", "type": "PasswordInput"},
+            {"name": "q", "type": "Text"},
+        ]})
+        _call(c, "set_input", {"component_id": "api_key", "value": self.SECRET})
+
+        _call(c, "set_form", {"specs": [{"name": "q", "type": "Text"}]})
+        self._assert_clean(_call(c, "describe_app"))
+        # The field is gone from the form, so its value is gone from the mirror —
+        # invoke must not keep passing it to the callback either.
+        assert "api_key" not in app._mcp_state.inputs
+
+
+class TestDynamicFormContract:
+    """#144, hardened: the contract follows the form on screen, whoever built it."""
+
+    def test_app_authored_form_is_validated(self):
+        # initial_specs never touched current_specs, so an app-authored form had
+        # no contract at all: unknown ids, out-of-range and wrong-typed values
+        # were all accepted in silence.
+        app = _dynamic_app(placeholder=None, initial_specs=[
+            {"name": "n", "type": "Slider", "props": {"min": 1, "max": 10}},
+        ])
+        c = _client_for(app)
+
+        assert _call(c, "set_input", {"component_id": "n", "value": 9999})["ok"] is False
+        assert _call(c, "set_input", {"component_id": "n", "value": "lots"})["ok"] is False
+        assert _call(c, "set_input", {"component_id": "bogus", "value": 1})["ok"] is False
+        assert _call(c, "set_input", {"component_id": "n", "value": 4})["ok"] is True
+
+    def test_parent_cascade_form_replaces_the_contract(self):
+        # A parent_control app's form is built server-side by the resolver. One
+        # set_form used to pin the contract forever: describe_app kept reporting
+        # the agent's form while the browser showed the cascade's, and set_input
+        # rejected the ids that were actually on screen.
+        app = _dynamic_app(
+            placeholder=None,
+            parent_control={"name": "dataset", "type": "Select",
+                            "props": {"data": ["sales", "traffic"]}},
+            spec_resolver=lambda v: [{"name": f"{v}_col", "type": "Text"}],
+        )
+        c = _client_for(app)
+
+        # The parent control is itself part of the contract — the UI passes it to
+        # the callback, so an agent must be able to discover and drive it.
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+        assert by_id["dataset"]["options"] == ["sales", "traffic"]
+        assert _call(c, "set_input", {"component_id": "dataset", "value": "nope"})["ok"] is False
+
+        _call(c, "set_form", {"specs": [{"name": "agent_field", "type": "Text"}]})
+        # The human now picks a dataset; the cascade rebuilds the form (this is
+        # what the reshape_from_parent callback does on every parent change).
+        app._sync_form_contract(app.spec_resolver("sales"), "sales")
+        ids = {i["id"] for i in _call(c, "describe_app")["inputs"]}
+        assert ids == {"dataset", "sales_col"}      # not the stale agent_field
+        assert _call(c, "set_input", {"component_id": "sales_col", "value": "x"})["ok"]
+
+
+class TestMcpExposureWarning:
+    """#149: warn about the host we actually bind, not the defunct mcp_host."""
+
+    def test_warns_when_bound_to_all_interfaces(self, monkeypatch):
+        app = _plain_app()
+        monkeypatch.setattr(app.app, "run", lambda **kw: None)
+        app.run_kwargs["host"] = "0.0.0.0"
+        with pytest.warns(UserWarning, match="no authentication"):
+            app.run()
+
+    def test_silent_on_loopback(self, monkeypatch):
+        app = _plain_app()
+        monkeypatch.setattr(app.app, "run", lambda **kw: None)
+        assert not _exposure_warnings(app.run)
+
+    def test_no_warning_when_no_mcp_route_is_mounted(self, monkeypatch):
+        # Multi-function mode ignores mcp_server=True, so there is no
+        # unauthenticated endpoint to warn about — warning anyway is the kind of
+        # false alarm that teaches people to ignore the real one.
+        def f(n: int = 1) -> str:
+            """f."""
+            return str(n)
+
+        def g(n: int = 2) -> str:
+            """g."""
+            return str(n)
+
+        app = FastDash(callback_fn=[f, g], mcp_server=True,
+                       run_kwargs={"host": "0.0.0.0"})
+        monkeypatch.setattr(app.app, "run", lambda **kw: None)
+        assert not _exposure_warnings(app.run)
+
+    def test_mcp_host_alone_does_not_warn(self):
+        # The legacy kwarg binds nothing now that MCP shares the app's port, so
+        # warning on it was a false alarm — and worse, its silence on a
+        # 0.0.0.0 run_kwargs host was a false all-clear.
+        def f(n: int = 1) -> str:
+            """f."""
+            return str(n)
+
+        warned = _exposure_warnings(
+            lambda: FastDash(callback_fn=f, mcp_server=True, mcp_host="0.0.0.0")
+        )
+        assert not warned
 
 
 # --- chat-mode MCP contract (RFC #133 Phase 3) ----------------------------- #

--- a/tests/test_typing_hints.py
+++ b/tests/test_typing_hints.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 """Tests for modern Python typing hints support in fast_dash."""
 
-from typing import Optional, Literal, Annotated, Union
+from typing import Optional, Literal, Annotated, Union, Tuple
 from enum import Enum
 
 from fast_dash import FastDash, dcc, dbc, dmc, html
@@ -292,3 +292,74 @@ def test_mixed_modern_hints():
 
     assert app.inputs_with_ids[2].__doc__ == dmc.TextInput().__doc__, "Third input should be a TextInput"
     assert app.inputs_with_ids[2].value == "Hello", "Optional[str] default should be preserved"
+
+
+########### Tuple return hints (#156) ###########
+
+
+def test_typing_tuple_return_hint_expands_to_multiple_outputs():
+    """`-> Tuple[str, str]` must produce one output per element.
+
+    A bare parenthesized `-> (str, str)` is a real tuple object, but the
+    idiomatic PEP 484 spelling is a generic *alias* — `isinstance(ann, tuple)`
+    is False for it — so it used to collapse to a single output and silently
+    drop every return value after the first (#156).
+    """
+    from typing import Tuple
+
+    def func(text: str = "hi") -> Tuple[str, str]:
+        return text, text.upper()
+
+    app = FastDash(callback_fn=func)
+    assert len(app.outputs_with_ids) == 2
+
+
+def test_pep585_tuple_return_hint_expands_to_multiple_outputs():
+    "The builtin-generic spelling `-> tuple[str, str]` behaves the same (#156)."
+
+    def func(text: str = "hi") -> tuple[str, str]:
+        return text, text.upper()
+
+    app = FastDash(callback_fn=func)
+    assert len(app.outputs_with_ids) == 2
+
+
+def test_bare_tuple_return_hint_still_single_output():
+    "A variadic `tuple[str, ...]` has no fixed arity — infer one output (#156)."
+
+    def func(text: str = "hi") -> tuple[str, ...]:
+        return (text,)
+
+    app = FastDash(callback_fn=func)
+    assert len(app.outputs_with_ids) == 1
+
+
+def test_mixed_tuple_return_hint_infers_each_component():
+    "Each element of the tuple hint drives its own component (#156)."
+    import plotly.graph_objects as go
+
+    def func(n: int = 3) -> Tuple[go.Figure, str]:
+        return go.Figure(), str(n)
+
+    app = FastDash(callback_fn=func)
+    assert len(app.outputs_with_ids) == 2
+    assert app.outputs_with_ids[0].__doc__ == dcc.Graph().__doc__
+
+
+def test_tuple_return_hint_under_future_annotations():
+    "A stringified `Tuple[...]` hint must still expand to multiple outputs (#156)."
+    from tests._tuple_hint_app import chart_and_caption
+
+    app = FastDash(callback_fn=chart_and_caption)
+    assert len(app.outputs_with_ids) == 2
+    assert app.outputs_with_ids[0].__doc__ == dcc.Graph().__doc__
+
+
+def test_module_named_return_annotation_keeps_by_name_fallback():
+    "`-> Image` (a PIL *module*) must still render an image, not an H1 (#156)."
+    from tests._pil_hint_app import make_thumb
+
+    app = FastDash(callback_fn=make_thumb)
+    assert len(app.outputs_with_ids) == 1
+    assert app.outputs_with_ids[0].tag == "Image"
+    assert app.outputs_with_ids[0].component_property == "src"


### PR DESCRIPTION
Closes #144, #147, #149, #150, #151, #152, #153, #156 — every open bug in the tracker.

The theme: **the MCP agent contract now describes what an app really is, and refuses what its UI could never produce.**

## Fixed

| Issue | Root cause | Fix |
|---|---|---|
| **#156** | `Tuple[int,str]` is a generic *alias*, not a tuple object → `isinstance(ann, tuple)` False | expand via `get_origin`/`get_args`; also resolve stringified hints under `from __future__ import annotations`. Variadic `tuple[int, ...]` correctly stays one output. |
| **#153** | `run_kwargs=dict()` mutable default, then mutated with the port → every app aliased one dict | copy, never alias; the caller's dict is untouched |
| **#151** | PasswordInput values handed out in plaintext over the **no-auth** `/mcp` route | secrets go in but never come back out: `"secret": true` + masked in `describe_app`, the `set_input` echo, and `get_invocation` |
| **#150** | bounds check gated on `isinstance(value, (int,float))` → a *string* sailed past a Slider's min/max | reject values of the wrong JSON type |
| **#144** | every guard keyed off the static input list, which `DynamicDash` doesn't have → **all** validation skipped | the form on screen *is* the contract — `initial_specs`, a `parent_control` cascade, or an agent's `set_form` alike; parent control included |
| **#149** | warning guarded `mcp_host` (binds nothing since MCP moved to the shared port) and was silent on `host="0.0.0.0"` | warns at `run()` on the host really bound, and only when a `/mcp` route is really mounted |
| **#147** | colour picker, textarea and text box all reported tag `"Text"` | each reports the widget it became |

## Added

**#152** — `describe_app` now reports the **output** contract (id, component tag, JSON type, label, plus the value currently on screen). Previously the only way for a headless agent to learn what an app returns was to *call* it: discovery by side effect.

## Found while fixing the above

- Output components' `tag` was never JSON-safe — an inferred `-> str` output carries the raw `<class 'str'>` object and an explicit `Table` carries `None`. Nothing had ever serialized it, so nobody noticed; `_output_kind()` now derives it from the rendered component.
- Resolving a stringified return annotation turned `-> Image` (the PIL **module**, which is what `from PIL import Image` binds) into an `<h1>`. Modules are now rejected so the by-name fallback still runs.

## Adversarial review

An adversarial pass over the first draft found three real leaks/regressions in code written for this PR, all fixed here and all now covered:

- a PasswordInput in an **app-authored** form (`initial_specs` / `parent_control`) was invisible to a secret list built only from `set_form` specs — its value was readable in the clear via three separate tools;
- a secret carried in a spec's `props` rode out verbatim **beside** the entry stamped `"secret": true`;
- one `set_form` permanently hijacked a `parent_control` app: `describe_app` reported a form that wasn't on screen, and `set_input` rejected the real field ids.

Tests now assert redaction by **substring over the whole serialized payload** (`SECRET not in json.dumps(payload)`), which is the only assertion a masked-sibling leak can't satisfy.

## Tests

31 new tests. Full local suite: **431 passed, 0 failed** (the 42 errors are `webdriver initialization failed` at fixture setup — local Chrome automation, not code; CI's selenium matrix is the arbiter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Bb7GNN8KmQzVt2Ws6rEM
