### PR TITLE
fix: finish the agent contract's widget discoverability (0.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
-# Release 0.6.3
+# Release 0.6.4
+
+## 0.6.4 (2026-07-15)
+
+Two agent-contract discoverability gaps the nightly dogfood found in 0.6.3.
+
+### Fixed
+- **`describe_app()` reported `outputs: []` for every `DynamicDash` app** (#160) —
+  the #152 output contract read the public `outputs_with_ids`, but `DynamicDash`
+  stores its outputs under `_outputs_with_ids`. It now reports the real outputs.
+- **`describe_app()` still reported `tag: "Text"` for a dropdown** (#158) — #147
+  named the widget for the ColorInput/TextArea branches only; the Select branch
+  and int/bool/date/Literal reported hint names absent from
+  `list_component_types()`. Every static input's `tag` now names the widget it
+  became and is a member of `list_component_types()`.
 
 ## 0.6.3 (2026-07-13)
 

--- a/docs/User guide/ai_agents.md
+++ b/docs/User guide/ai_agents.md
@@ -57,7 +57,7 @@ use that to build a valid `invoke` call:
   "title": "Plot Bars",
   "doc": "Plot a bar chart with n bars in the chosen color.",
   "inputs": [
-    {"id": "n",     "tag": "Slider",     "type": "integer", "default": 6,         "options": null, "current_value": 6,         "secret": false},
+    {"id": "n",     "tag": "NumberInput", "type": "integer", "default": 6,        "options": null, "current_value": 6,         "secret": false},
     {"id": "color", "tag": "ColorInput", "type": "string",  "default": "#1c7ed6", "options": null, "current_value": "#1c7ed6", "secret": false}
   ],
   "outputs": [

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,35 @@
 # History
 
+# Release 0.6.4
+
+## 0.6.4 (2026-07-15)
+
+A follow-up to the 0.6.3 agent-contract work: two discoverability gaps the
+nightly dogfood found in the parts of it that didn't cover every path.
+
+### Fixed
+
+- **`describe_app()` reported `outputs: []` for every `DynamicDash` app** ([#160]).
+  The 0.6.3 output contract ([#152]) read the public `outputs_with_ids`, but
+  `DynamicDash` keeps its prepared outputs under `_outputs_with_ids`, so a
+  headless agent driving a `DynamicDash` was pushed right back into discovering
+  outputs by *running* the app — the exact thing the output contract exists to
+  prevent. It now reports the real outputs (matching the ids `invoke` produces),
+  the same private-name fallback `_enumerate_outputs` already used.
+- **`describe_app()` still reported `tag: "Text"` for a dropdown** ([#158]). The
+  #147 widget-tag fix covered the `ColorInput` and `TextArea` branches but left
+  the sibling `Select` branch and the numeric / boolean / date / `Literal`
+  branches reporting the *hint* name — so a `str`-with-list-default dropdown was
+  indistinguishable from a plain text box (the very #147 failure mode), and
+  `int`/`bool`/`date`/`Literal` reported internal names (`"Numeric"`,
+  `"Boolean"`, `"Date"`, `"Literal"`) absent from `list_component_types()`. Every
+  static input's `tag` now names the widget it actually became — `Select`,
+  `NumberInput`, `Slider`, `Switch`, `DateInput`, `MultiSelect`, `UploadImage` —
+  and is guaranteed to be a member of `list_component_types()`.
+
+[#158]: https://github.com/dkedar7/fast_dash/issues/158
+[#160]: https://github.com/dkedar7/fast_dash/issues/160
+
 # Release 0.6.3
 
 ## 0.6.3 (2026-07-13)

--- a/fast_dash/__init__.py
+++ b/fast_dash/__init__.py
@@ -2,7 +2,7 @@
 
 __author__ = """Kedar Dabhadkar"""
 __email__ = "kedar@fastdash.app"
-__version__ = "0.6.3"
+__version__ = "0.6.4"
 
 from fast_dash.Components import (
     Graph,

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -634,7 +634,9 @@ def _describe_static_inputs(fd, snapshot):
         cur = snapshot.get(cid, snapshot.get(param))
         entry = {
             "id": cid,
-            "tag": d["tag"],
+            # The widget actually rendered, named as list_component_types() --
+            # not the hint name static inference stamps on `tag` (#147/#158).
+            "tag": _input_widget_tag(components.get(cid), d["tag"]),
             "type": jtype,
             "options": _jsonify_for_mcp(options),
             "secret": cid in secrets,          # PasswordInput: value never echoed (#151)
@@ -677,6 +679,54 @@ def _output_kind(comp):
     return _OUTPUT_KIND.get(name, (name, "object"))
 
 
+# Live widget class -> the canonical widget name from list_component_types()
+# (the DynamicDash COMPONENT_REGISTRY keys). What static inference *actually*
+# builds, empirically -- e.g. a hex-default str becomes a dmc.ColorInput, a
+# list-default str becomes a dmc.Select, a bool becomes a dmc.Checkbox (whose
+# spec-level equivalent is "Switch").
+_INPUT_WIDGET_TAG = {
+    "TextInput": "Text",
+    "Textarea": "TextArea",
+    "ColorInput": "ColorInput",
+    "PasswordInput": "PasswordInput",
+    "NumberInput": "NumberInput",
+    "Slider": "Slider",
+    "RangeSlider": "Slider",
+    "Select": "Select",
+    "MultiSelect": "MultiSelect",
+    "Checkbox": "Switch",
+    "Switch": "Switch",
+    "DatePickerSingle": "DateInput",
+    "DateInput": "DateInput",
+    "DatePickerRange": "DateRange",
+    "DatePickerInput": "DateRange",
+    "Markdown": "Markdown",
+}
+
+
+def _input_widget_tag(component, raw_tag):
+    """The widget a static input actually became, named as list_component_types().
+
+    ``describe_app`` reports whatever ``tag`` the component was built with, but
+    static inference stamps the *hint* name there, not the widget's: a
+    list-default ``str`` renders a Select yet carries tag ``"Text"`` (identical
+    to a plain text box), and int/bool/date/Literal carry internal names
+    (``"Numeric"``/``"Boolean"``/``"Date"``/``"Literal"``) that aren't in
+    ``list_component_types()`` at all (#147 fixed only the ColorInput/TextArea
+    branches; #158 is the rest). The raw tag can't be trusted -- that Select
+    literally says ``"Text"`` -- so read the live widget class, which is honest.
+    Fall back to the raw tag for a user-supplied component we don't recognize.
+    """
+    # The image-upload widget is a bare dcc.Upload; only its construction tag
+    # distinguishes it from a file upload.
+    if raw_tag == "Image":
+        return "UploadImage"
+    name = type(getattr(component, "component", component)).__name__
+    if name == "Upload":
+        return "UploadImage" if raw_tag == "Image" else "Upload"
+    return _INPUT_WIDGET_TAG.get(name, raw_tag)
+
+
 def _describe_outputs(fd, state=None):
     """Per-output contract: what ``invoke`` will produce, without running it.
 
@@ -688,7 +738,15 @@ def _describe_outputs(fd, state=None):
     from fast_dash.Components import expand_return_annotation
     from fast_dash.utils import _summarize_for_history
 
-    components = list(getattr(fd, "outputs_with_ids", None) or [])
+    # DynamicDash stores its prepared outputs under the private name, same as
+    # _enumerate_outputs already reaches for — without this fallback the output
+    # contract was empty for every DynamicDash app, pushing an agent right back
+    # into discovering outputs by running the app (#160).
+    components = list(
+        getattr(fd, "outputs_with_ids", None)
+        or getattr(fd, "_outputs_with_ids", None)
+        or []
+    )
     anns = []
     # Only consult the annotation when the outputs were built *from* it. An
     # explicit `outputs=[Graph]` wins over a `-> str` hint, and the contract has

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool]
 [project]
 name = "fast_dash"
-version = "0.6.3"
+version = "0.6.4"
 homepage = "https://github.com/dkedar7/fast_dash"
 documentation = "https://docs.fastdash.app"
 description = "Turn your Python functions into interactive web applications. Fast Dash is an innovative way to build and deploy your Python code as interactive apps with minimal changes to your original code."

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -17,7 +17,7 @@ import enum
 import importlib.util
 import json
 import warnings
-from typing import Annotated, Optional, Tuple  # module-level for get_type_hints (#119, #132)
+from typing import Annotated, Literal, Optional, Tuple  # module-level for get_type_hints (#119, #132)
 
 import pandas as pd  # noqa: F401  (module-level for any -> pd.DataFrame hints)
 import plotly.graph_objects as go
@@ -640,6 +640,27 @@ class TestTools:
         after = _call(c, "describe_app")["outputs"]
         assert after[1]["current_value"] == "4 bars"   # live value, still typed
 
+    def test_dynamicdash_output_contract_is_not_empty(self):
+        # #160: the #152 output contract read the public `outputs_with_ids`, but
+        # DynamicDash stores its prepared outputs under `_outputs_with_ids`, so
+        # describe_app reported `outputs: []` for every DynamicDash — pushing an
+        # agent right back into discovering outputs by running the app. The
+        # contract must match the ids invoke() actually produces.
+        app = _dynamic_app()
+        c = _client_for(app)
+
+        outs = _call(c, "describe_app")["outputs"]
+        assert [(o["id"], o["tag"]) for o in outs] == [
+            ("dyn-output-0", "Graph"), ("dyn-output-1", "Markdown")]
+
+        _call(c, "set_form", {"specs": [{"name": "x", "type": "Slider",
+                                         "props": {"min": 0, "max": 10}}]})
+        _call(c, "set_inputs", {"inputs": {"x": 5}})
+        run = _call(c, "invoke", {"inputs": {}})
+        # The contract predicted exactly the ids a run produces — no need to run
+        # to find out.
+        assert set(run["outputs"]) == {o["id"] for o in outs}
+
     def test_str_hint_widgets_report_the_widget_they_became(self):
         # #147: a colour picker, a textarea and a text box are three different
         # widgets, but all three reported tag "Text" (the `str` hint), so a
@@ -656,6 +677,46 @@ class TestTools:
         assert by_id["color"]["tag"] == "ColorInput"
         assert by_id["bio"]["tag"] == "TextArea"
         assert by_id["name"]["tag"] == "Text"
+
+    def test_every_static_input_tag_is_a_real_widget_type(self):
+        # #158: #147 named the widget for the ColorInput/TextArea/Text branches
+        # but left the rest reporting the *hint* name. A str-with-list-default
+        # renders a Select yet reported "Text" (== a plain text box, the exact
+        # #147 failure mode), and int/bool/date/Literal reported internal names
+        # ("Numeric"/"Boolean"/"Date"/"Literal") absent from
+        # list_component_types(). The invariant: every static input's tag names a
+        # real widget an agent could reproduce with set_form.
+        # Hints must use module-level names (`datetime`, `Literal`) so
+        # get_type_hints resolves them under this file's future annotations —
+        # a function-local import would degrade to a text box (#119).
+        def demo(plain: str = "hi",
+                 choice: str = ["a", "b", "c"],          # -> Select
+                 lit: Literal["x", "y"] = "x",           # -> Select
+                 n: int = 5,                             # -> NumberInput
+                 rng: Annotated[int, range(0, 10)] = 5,  # -> Slider
+                 flag: bool = True,                      # -> Switch
+                 day: datetime.date = datetime.date(2024, 1, 1),  # -> DateInput
+                 tags: list = ["a", "b"]) -> str:        # -> MultiSelect
+            """Every widget kind."""
+            return "x"
+
+        c = _client_for(FastDash(callback_fn=demo, mcp_server=True))
+        legal = set(_call(c, "list_component_types")["types"])
+        by_id = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}
+
+        # The headline: a fixed-choice dropdown is no longer indistinguishable
+        # from a free-text box.
+        assert by_id["choice"]["tag"] == "Select"
+        assert by_id["plain"]["tag"] == "Text"
+        assert by_id["choice"]["tag"] != by_id["plain"]["tag"]
+
+        expected = {"plain": "Text", "choice": "Select", "lit": "Select",
+                    "n": "NumberInput", "rng": "Slider", "flag": "Switch",
+                    "day": "DateInput", "tags": "MultiSelect"}
+        assert {k: by_id[k]["tag"] for k in expected} == expected
+        # ...and every one is a type an agent could name in set_form.
+        for i in by_id.values():
+            assert i["tag"] in legal, f"{i['id']} tag {i['tag']!r} not in {sorted(legal)}"
 
     def test_password_value_goes_in_but_never_comes_back(self):
         # #151: the browser masks a PasswordInput; the unauthenticated /mcp route


### PR DESCRIPTION
Closes #158 and #160 — two agent-contract discoverability gaps the nightly dogfood (#101) found in the 0.6.3 work, both where that work didn't cover every path.

## #160 — `describe_app().outputs` was `[]` for every `DynamicDash`

The 0.6.3 output contract (#152) read the **public** `outputs_with_ids`, but `DynamicDash` keeps its prepared outputs under `_outputs_with_ids`, so `getattr(fd, "outputs_with_ids", None)` returned `None` and the contract short-circuited to `[]` — before *and* after `set_form`. A headless agent driving a `DynamicDash` (the app type whose whole point is agent-driven forms) was pushed right back into discovering outputs by *running* the app, exactly what the output contract exists to prevent.

Fix: the same private-name fallback `_enumerate_outputs` already used. The contract now reports the real outputs and matches the ids `invoke()` produces.

## #158 — a dropdown still reported `tag: "Text"`

#147 named the widget for the `ColorInput`/`TextArea` branches but left the **sibling `Select` branch** and the numeric/boolean/date/`Literal` branches reporting the *hint* name. On 0.6.3:

- a `str`-with-list-default renders a **`Select`** but reported `"Text"` — indistinguishable from a plain text box (the exact #147 failure mode);
- `int`/`float` → `"Numeric"`, `bool` → `"Boolean"`, `date` → `"Date"`, `Literal` → `"Literal"` — none of which appear in `list_component_types()`.

Fix: derive the tag from the **live widget class** (the way `_output_kind` already does for outputs), not the construction tag — because the construction tag can't be trusted here: that `Select` literally carries `tag="Text"`. Every static input now names the widget it became (`Select`, `NumberInput`, `Slider`, `Switch`, `DateInput`, `MultiSelect`, `UploadImage`, …) and is guaranteed to be a member of `list_component_types()`.

Chose the **contract layer** over rewriting construction-time tags because those are load-bearing — `_transform_inputs` keys the base64→PIL image transform off `tag == "Image"`, and the output path checks `tag in ("Literal","Enum")`. Normalizing in `describe_app` fixes discoverability with zero risk to rendering or callbacks, and is symmetric with the #152 output fix.

## Tests

- `test_every_static_input_tag_is_a_real_widget_type` — asserts the invariant the issue asked for: every static input's `tag ∈ list_component_types()`, and `Select` ≠ `Text` (the headline).
- `test_dynamicdash_output_contract_is_not_empty` — the DynamicDash output contract is populated and predicts exactly the ids `invoke()` returns.

398 headless tests pass locally; CI runs the selenium matrix (the arbiter for the browser tests, which can't start Chrome on this box).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E6Bb7GNN8KmQzVt2Ws6rEM
