### PR TITLE
fix(mcp): agent output visibility, structured tool errors, MultiSelect type (#164, #165, #162)

### DIFF
--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -1511,15 +1511,22 @@ class FastDash(ChatAppMixin):
                 [
                     Output(c.id, c.component_property, allow_duplicate=True)
                     for c in self.outputs_with_ids
-                ],
+                ]
+                # ...and reveal the output pane. The pre-run placeholder is a
+                # `.fd-not-run` class cleared only by the human Run button's
+                # click count, so an agent's output landed in a leaf that CSS
+                # still had at `visibility: hidden` until someone clicked Run
+                # once. Clearing it here makes "agent drives, human watches"
+                # true on a freshly-loaded page. (issue #164)
+                + [Output("output-group-col", "className", allow_duplicate=True)],
                 Input("_mcp_poll", "n_intervals"),
                 prevent_initial_call=True,
             )
             def _mcp_drain_outputs(_n):
                 pending = state.pop_pending_outputs()
                 if not pending:
-                    return [no_update] * len(self.outputs_with_ids)
-                return self._mcp_apply_output_transforms(pending)
+                    return [no_update] * (len(self.outputs_with_ids) + 1)
+                return self._mcp_apply_output_transforms(pending) + [""]
 
     def _register_mcp_ws_drain(self):
         """Real-time server -> browser push over a persistent WebSocket.
@@ -1551,6 +1558,10 @@ class FastDash(ChatAppMixin):
                     for c, val in zip(self.outputs_with_ids, transformed):
                         if val is not no_update:
                             set_props(c.id, {c.component_property: val})
+                    # Same pre-run placeholder gate as the Interval drain --
+                    # reveal the output pane so a watching human sees the
+                    # agent's result without clicking Run first. (issue #164)
+                    set_props("output-group-col", {"className": ""})
 
                 await asyncio.sleep(0.05)
 

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -59,6 +59,7 @@ from __future__ import annotations
 
 import collections
 import datetime
+import functools
 import inspect
 import os
 import time
@@ -632,11 +633,20 @@ def _describe_static_inputs(fd, snapshot):
                 # else (range / arbitrary objects): leave default None so the
                 # contract never carries a non-JSON repr (issue #116).
         cur = snapshot.get(cid, snapshot.get(param))
+        # The widget actually rendered, named as list_component_types() --
+        # not the hint name static inference stamps on `tag` (#147/#158).
+        tag = _input_widget_tag(components.get(cid), d["tag"])
+        # A MultiSelect's value is an *array* of selected option keys, whatever
+        # the annotation implied. A ``dict`` default renders a MultiSelect over
+        # its keys, so the annotation-derived "object" would advertise a value
+        # the UI can never produce and the validators reject. Reconcile the
+        # declared type with the widget actually rendered -- the same answer
+        # _SPEC_JSON_TYPE already gives on the DynamicDash path. (issue #162)
+        if tag == "MultiSelect":
+            jtype = "array"
         entry = {
             "id": cid,
-            # The widget actually rendered, named as list_component_types() --
-            # not the hint name static inference stamps on `tag` (#147/#158).
-            "tag": _input_widget_tag(components.get(cid), d["tag"]),
+            "tag": tag,
             "type": jtype,
             "options": _jsonify_for_mcp(options),
             "secret": cid in secrets,          # PasswordInput: value never echoed (#151)
@@ -829,6 +839,46 @@ def _option_error(fd, component_id, value, snapshot, state=None):
 # Native MCP mount + fast_dash tool registration
 # --------------------------------------------------------------------------- #
 
+def _structured_errors(fn):
+    """Keep a drive tool's error contract structured, even on a malformed call.
+
+    A missing required argument raises ``TypeError`` *when Python calls the
+    function* -- before its body runs -- so the tool's own ``try/except`` can
+    never catch it, and the raw exception (which spells out the internal
+    ``enable_mcp.<locals>.<tool>`` qualname) reaches the agent instead of the
+    ``{"ok": false, "error": ...}`` shape every other error path on these tools
+    returns. Bind the arguments here instead and report a missing or unexpected
+    one in the contract's own shape.
+
+    ``functools.wraps`` keeps the wrapped signature, so Dash still derives the
+    same MCP input schema -- the arguments stay *required* in the schema; they
+    just fail in the contract's shape rather than as a traceback. (issue #165)
+    """
+    sig = inspect.signature(fn)
+    required = [
+        p.name for p in sig.parameters.values()
+        if p.default is inspect.Parameter.empty
+        and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+    ]
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        try:
+            sig.bind(*args, **kwargs)
+        except TypeError as e:
+            return {
+                "ok": False,
+                "error": f"{fn.__name__}() {e}",
+                "required_arguments": required,
+            }
+        try:
+            return fn(*args, **kwargs)
+        except Exception as e:  # noqa: BLE001 - never leak a traceback over /mcp
+            return {"ok": False, "error": f"{type(e).__name__}: {e}"}
+
+    return wrapper
+
+
 def _ensure_dash_mcp():
     """Import Dash's native MCP API, with a clear error if too old."""
     try:
@@ -875,6 +925,7 @@ def _register_chat_mcp_tools(fd, mcp_enabled) -> None:
     from fast_dash.utils import _jsonify_for_mcp
 
     @mcp_enabled(name="describe_app", expose_docstring=True)
+    @_structured_errors
     def describe_app() -> dict:
         """Describe this chat app's contract for a headless agent.
 
@@ -890,6 +941,7 @@ def _register_chat_mcp_tools(fd, mcp_enabled) -> None:
         }
 
     @mcp_enabled(name="invoke", expose_docstring=True)
+    @_structured_errors
     def invoke(query: str, settings: dict = None) -> dict:
         """Run one chat turn headlessly and return its frames (JSON-safe).
 
@@ -986,6 +1038,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         return _jsonify_for_mcp(_redact(entries.get(cid) or {}, value))
 
     @mcp_enabled(name="set_input", expose_docstring=True)
+    @_structured_errors
     def set_input(component_id: str, value: Any) -> dict:
         """Update one input's value, server-side and live in the browser.
 
@@ -1007,6 +1060,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         return {"ok": True, "id": component_id, "value": _echo(entries, component_id, value)}
 
     @mcp_enabled(name="set_inputs", expose_docstring=True)
+    @_structured_errors
     def set_inputs(inputs: dict) -> dict:
         """Bulk-update multiple input values (keyed by parameter name).
 
@@ -1030,6 +1084,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         return {"ok": not errors, "applied": applied, "errors": errors}
 
     @mcp_enabled(name="invoke", expose_docstring=True)
+    @_structured_errors
     def invoke(inputs: dict = None) -> dict:
         """Run the app's callback with the current input mirror.
 
@@ -1131,6 +1186,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         }
 
     @mcp_enabled(name="set_form", expose_docstring=True)
+    @_structured_errors
     def set_form(specs: list) -> dict:
         """Replace the form on a DynamicDash app with a new spec list.
 
@@ -1158,6 +1214,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         return {"ok": True, "count": len(specs)}
 
     @mcp_enabled(name="get_invocation", expose_docstring=True)
+    @_structured_errors
     def get_invocation(index: int) -> dict:
         """Look up a past invocation by history index (returned by invoke)."""
         if index not in state.full_history:
@@ -1176,11 +1233,13 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         }
 
     @mcp_enabled(name="list_component_types", expose_docstring=True)
+    @_structured_errors
     def list_component_types() -> dict:
         """List the legal ``type`` values for a DynamicDash UI spec."""
         return {"types": _component_types()}
 
     @mcp_enabled(name="describe_app", expose_docstring=True)
+    @_structured_errors
     def describe_app() -> dict:
         """Describe the app's inputs and outputs, plus their CURRENT values.
 

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1082,3 +1082,74 @@ class TestSidecarMcp:
             app._run_chat_turn("go", "s1", "sock", (), app_inputs={"revenue": 100})
         rev = [i for i in _call(c, "describe_app")["inputs"] if i["id"] == "revenue"]
         assert rev and rev[0]["current_value"] == 500
+
+
+class TestMcpBugBatch:
+    """Regressions for the three MCP bugs filed by the nightly dogfood."""
+
+    def test_dict_default_reports_array_not_object(self):
+        # #162: a `dict` default renders a MultiSelect, whose value is an *array*
+        # of selected keys -- but describe_app reported the annotation-derived
+        # "object", advertising a value the UI can never produce and the
+        # validators themselves reject.
+        def shop(items: dict = {"apples": 1, "pears": 2, "figs": 3}) -> str:
+            """Echo selection."""
+            return str(items)
+
+        c = _client_for(FastDash(callback_fn=shop, mcp_server=True))
+        entry = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}["items"]
+        assert entry["tag"] == "MultiSelect"
+        assert entry["type"] == "array"          # was "object"
+        # The contract now matches enforcement in both directions.
+        ok = _call(c, "set_input", {"component_id": "items", "value": ["apples"]})
+        assert ok["ok"] is True
+        bad = _call(c, "set_input", {"component_id": "items", "value": {"apples": 1}})
+        assert bad["ok"] is False
+
+    def test_list_default_still_reports_array(self):
+        # The `list` sibling was already correct; keep it that way.
+        def pick(flavors: list = ["a", "b"]) -> str:
+            """Echo."""
+            return str(flavors)
+
+        c = _client_for(FastDash(callback_fn=pick, mcp_server=True))
+        entry = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}["flavors"]
+        assert entry["type"] == "array"
+
+    def test_missing_required_arg_returns_structured_error(self):
+        # #165: omitting a required argument raised a raw TypeError whose text
+        # leaked the internal `enable_mcp.<locals>.<tool>` qualname -- the only
+        # error path on these tools that wasn't the structured contract.
+        c = _client_for(_plain_app())
+        for tool in ("set_input", "set_inputs", "set_form", "get_invocation"):
+            out = _call(c, tool, {})
+            assert isinstance(out, dict), f"{tool} returned {out!r}"
+            assert out.get("ok") is False, f"{tool} should fail structurally: {out}"
+            assert out.get("required_arguments"), f"{tool} should name its args"
+            blob = json.dumps(out)
+            assert "enable_mcp" not in blob, f"{tool} leaked internals: {blob}"
+            assert "<locals>" not in blob, f"{tool} leaked internals: {blob}"
+
+    def test_tool_body_exception_is_structured_too(self):
+        # The same guard keeps any in-body failure in the contract's shape
+        # rather than surfacing a traceback over /mcp.
+        c = _client_for(_plain_app())
+        out = _call(c, "get_invocation", {"index": "not-an-index"})
+        assert isinstance(out, dict) and out.get("ok") is False
+
+    def test_agent_output_drain_clears_the_pre_run_placeholder(self):
+        # #164: the pre-run `.fd-not-run` gate on #output-group-col was cleared
+        # only by the human Run button's click count, so an agent invoke()'s
+        # output landed in a leaf CSS still hid -- a watching human saw the
+        # mirrored inputs above a stale "Run to see results" placeholder until
+        # someone clicked Run once. The output drain must clear the gate too.
+        app = _plain_app()
+        drains = [
+            cb for cb in app.app.callback_map.values()
+            if any(i.get("id") == "_mcp_poll" for i in cb.get("inputs", []))
+        ]
+        assert drains, "MCP poll drain callbacks should be registered"
+        targets = {str(o) for cb in drains for o in cb.get("output", [])}
+        assert any("output-group-col.className" in t for t in targets), (
+            "the MCP output drain must also clear the pre-run .fd-not-run gate"
+        )


### PR DESCRIPTION
Fixes the three MCP bugs filed by the nightly dogfood, as one batch — they're all in the drive-tool/contract surface and share tests.

## #164 — agent output never rendered until the first human Run
The pre-run placeholder is a `.fd-not-run` class on `#output-group-col`, cleared **only** by the Run button's click count. An agent `invoke()` wrote its result into a leaf CSS still had at `visibility: hidden`, so a watching human saw the mirrored *inputs* above a stale `Run to see results` — the exact "agent drives, human watches" scenario the feature is sold on.

Both drains now clear the gate when they push an output: the Interval one (Flask) and the ASGI WebSocket `set_props` path.

## #165 — drive tools leaked a raw `TypeError`
A missing required argument raises **at call time, before the body runs**, so the tools' own `try/except` could never catch it and the internal `enable_mcp.<locals>.<tool>` qualname reached the agent — the only error path on these tools that wasn't the structured contract.

New `_structured_errors` wrapper binds the arguments itself and reports a missing/unexpected one in the contract's shape (and catches in-body failures too). `functools.wraps` keeps the signature, so **Dash still derives the same MCP input schema — the arguments stay `required`**; they just fail in the contract's shape instead of as a traceback.

Applied to every fast_dash-registered tool, including the chat `invoke(query)` — same defect, not in the report.

```
set_input()  -> {"ok": false, "error": "set_input() missing a required argument: 'component_id'",
                 "required_arguments": ["component_id", "value"]}
```

## #162 — `dict`-default reported as `object`, MultiSelect needs an array
`describe_app()` advertised `type: "object"` for a `dict` default, but the MultiSelect it renders only accepts/produces an **array of keys** — a value the UI can never produce and the validators themselves reject. The declared type is now reconciled with the rendered widget, the same answer `_SPEC_JSON_TYPE` already gives on the DynamicDash path. (Kept targeted to MultiSelect: applying the whole map would downgrade `int`'s precise `"integer"` to `"number"`.)

## Verification
Not just in-process — against the **real wires**, using the issues' own repros:

- **#162 / #165** — live app driven over streamable-HTTP with the `mcp` SDK client: `type` is now `array`, the array is accepted and the object rejected; all four tools return the structured shape with **no** `enable_mcp` / `<locals>` leak.
- **#164** — Dash's `/_dash-update-component` (the channel the browser actually uses): the drain response now carries `output-group-col.className = ""` alongside the output. A full browser pass needs Playwright, which isn't available in this environment.

## Tests
5 new regressions in `tests/test_mcp.py::TestMcpBugBatch` (array type + contract/enforcement agreement, the `list` sibling staying correct, structured missing-arg errors with no internals leaked, in-body failures structured, and the drain wiring that clears the pre-run gate). Full MCP-related suites green: **318 passed**.

Closes #164, closes #165, closes #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
