### PR TITLE
fix: render output for no-input callbacks (update_live apps never gate)

### DIFF
--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -1830,11 +1830,26 @@ class FastDash(ChatAppMixin):
         # count only, so it fires instantly and isn't deferred by the run.
         # (The loading skeleton is driven separately by the process_input
         # `running=` bracket on #output-loading-wrap — see register_callback_fn.)
-        self.app.clientside_callback(
-            "function(n) { return (n && n > 0) ? '' : 'fd-not-run'; }",
-            Output("output-group-col", "className"),
-            Input("submit_inputs", "n_clicks"),
-        )
+        #
+        # ...but an `update_live` app has no Run step: it recomputes on load and
+        # on every input change. Every 0-input callback auto-enables update_live
+        # (a function that takes no inputs is "supposed to run as-is and display
+        # its output"). Gating those behind the Run placeholder hid the output
+        # the initial auto-run had already computed -- `.fd-not-run` forces the
+        # placeholder visible AND sets the content to visibility:hidden -- so the
+        # app rendered blank. update_live apps therefore never gate.
+        if self.update_live:
+            self.app.clientside_callback(
+                "function(n) { return ''; }",
+                Output("output-group-col", "className"),
+                Input("submit_inputs", "n_clicks"),
+            )
+        else:
+            self.app.clientside_callback(
+                "function(n) { return (n && n > 0) ? '' : 'fd-not-run'; }",
+                Output("output-group-col", "className"),
+                Input("submit_inputs", "n_clicks"),
+            )
 
         # Native streaming makes the main callback a WebSocket callback so
         # set_props can stream partial updates mid-execution. The legacy Flask

--- a/tests/test_run_button.py
+++ b/tests/test_run_button.py
@@ -52,3 +52,43 @@ def test_app_layout_contains_run_button():
     layout_str = str(app.app.layout)
     assert "'Run'" in layout_str or '"Run"' in layout_str
     assert '"Submit"' not in layout_str and "'Submit'" not in layout_str
+
+
+def _classname_gate_js(app):
+    """The clientside JS registered for #output-group-col.className."""
+    hit = next(
+        cb for cb in app.app._callback_list
+        if "output-group-col.className" in str(cb.get("output", ""))
+    )
+    fn_hash = hit["clientside_function"]["function_name"]
+    return next(s for s in app.app._inline_scripts if fn_hash in s)
+
+
+def test_no_input_app_does_not_gate_output_behind_placeholder():
+    """A 0-input callback auto-enables update_live and must render on load.
+
+    Regression: the pre-run `.fd-not-run` placeholder gate (keyed only on the
+    Run button's click count) hid the output the initial auto-run had already
+    computed, so the app rendered blank. update_live apps have no Run step, so
+    the gate must never engage for them.
+    """
+    import plotly.graph_objects as go
+
+    def dashboard() -> go.Figure:
+        return go.Figure(go.Bar(x=["a", "b"], y=[3, 1]))
+
+    app = FastDash(callback_fn=dashboard)
+    assert app.update_live is True           # auto-enabled for 0 inputs
+    js = _classname_gate_js(app)
+    assert "fd-not-run" not in js            # never gates -> output is shown
+
+
+def test_run_mode_app_still_gates_until_first_run():
+    """A normal Run-mode app keeps the pre-run placeholder until the first Run."""
+    def f(x: str = "hi") -> str:
+        return x
+
+    app = FastDash(callback_fn=f)             # 1 input, update_live stays False
+    assert app.update_live is False
+    js = _classname_gate_js(app)
+    assert "fd-not-run" in js                 # gate preserved


### PR DESCRIPTION
## The bug (reported directly)
A callback that takes **no inputs** is supposed to "run as-is and display its rendered components" — but the app renders **blank**.

## What's actually happening
The function *does* run: a 0-input callback auto-enables `update_live`, and `process_input` executes it on the initial callback and returns a populated output. The result is just never shown.

The culprit is the pre-run placeholder gate:
- `.fd-not-run` on `#output-group-col` forces the "Run to see results" placeholder visible (`!important`, overriding the content-detection `:has()` rules) **and** sets the output content to `visibility: hidden`.
- That class is cleared only by a clientside callback keyed on the **Run button's `n_clicks`** — but an `update_live` app has no Run step, so on load `n_clicks` is 0, the gate stays on, and nothing ever clears it.

So the computed output sits in a leaf that CSS is hiding → blank.

## Fix
The placeholder is a *Run-mode* concept. `update_live` apps (every 0-input app, plus any explicitly `update_live` one) recompute on load / on change with no Run, so they now **never gate** — the `className` clientside returns `''` for them. Run-mode apps are unchanged and still show the placeholder until the first Run.

## Verification
Confirmed over Dash's **real update wire**:
- `process_input` runs the 0-input callback on load and returns a populated figure.
- The `className` gate JS registered for an `update_live` app is now the non-gating `function(n) { return ''; }`; a Run-mode app still gets the `fd-not-run` gate.

Same placeholder-gate family as #164 (agent-`invoke()` output), on the no-input/`update_live` path.

## Tests
2 new in `tests/test_run_button.py` (0-input app doesn't gate; Run-mode app still does), asserting on the registered clientside JS. Non-browser suites green: **198 passed**. The Selenium `test_fast_dash.py` pass runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
