### PR TITLE
fix: six dogfood findings — MCP contract, ASGI startup, ASCII errors, docs (#169-#173, #176)

### DIFF
--- a/docs/User guide/build.md
+++ b/docs/User guide/build.md
@@ -104,7 +104,7 @@ Fast Dash uses these type hints to determine which UI components to use. For exa
 
 Fast Dash understands two types of type hints—one, in-built Python data type classes (`str`, `int`, `float`, `list`, `dict`, etc.), and two, [Dash Components](components.md) directly.
 
-In addition to type hints, the input arguments can also have default values. In the example below, the default value of string `a` is `Fast`, that of integer `b` is `5`, and `c` is a `list` with a default value of `[1, 2, 3]`. The function returns a single string value, as indicated by the return variable type hint (`-> str:`).
+In addition to type hints, the input arguments can also have default values. In the example below, string `a` starts out as `Fast` and integer `b` as `5`. The function returns a single string value, as indicated by the return variable type hint (`-> str:`).
 
 ```py hl_lines="1 2 3"
 def your_function(a: str = "Fast", 
@@ -112,6 +112,19 @@ def your_function(a: str = "Fast",
                   c: list = [1, 2, 3]) -> str:
     ...
 ```
+
+!!! warning "Collection defaults set the *choices*, not the starting value"
+
+    A **scalar** default (`a`, `b` above) becomes the widget's starting value. A
+    **collection** default — a `list`, a `dict`, or a `range()` — is used instead to
+    build the widget's *option set*: `c: list = [1, 2, 3]` renders a multi-select
+    offering `1`, `2` and `3` **with nothing selected**, so an untouched Run calls
+    your function with `c=None`, not `c=[1, 2, 3]`.
+
+    This matters when your function is written to rely on its own default — a body
+    that does `sum(c)` works when you call `your_function()` directly but raises
+    `TypeError: 'NoneType' object is not iterable` on the first Run. Guard the
+    parameter (`c = c or [1, 2, 3]`) if it must never be empty.
 
 Fast Dash determines the best components for each input using their hints and default values. Details about which combination of these values results in what components are in the [patterns documentation](patterns.md).
 

--- a/fast_dash/dynamic.py
+++ b/fast_dash/dynamic.py
@@ -218,8 +218,8 @@ class DynamicDash:
     ):
         if parent_control is not None and spec_resolver is None:
             raise ValueError(
-                "parent_control was given but spec_resolver is None — "
-                "supply a callable that maps parent value → list of specs."
+                "parent_control was given but spec_resolver is None - "
+                "supply a callable that maps parent value to a list of specs."
             )
 
         self.callback_fn = callback_fn

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -1387,8 +1387,16 @@ class FastDash(ChatAppMixin):
         # else loopback), so the address we bind is the address we warned about.
         host = effective_bind_host(self.run_kwargs)
         port = self.run_kwargs.get("port", self.port)
+
+        # Announce the URL, as the Flask backend does ("Dash is running on
+        # ..."). Serving the ASGI app object bypasses Dash's own run(), which is
+        # what prints that line, and uvicorn at log_level="warning" says nothing
+        # either -- so this path booted in total silence: no URL to open and no
+        # way to tell a running server from a hung one (issue #170). uvicorn's
+        # own startup/shutdown lines come back at "info" for the same reason.
+        print(f"Dash is running on http://{host}:{port}/\n", flush=True)
         uvicorn.Server(
-            uvicorn.Config(self.app.server, host=host, port=port, log_level="warning")
+            uvicorn.Config(self.app.server, host=host, port=port, log_level="info")
         ).run()
 
     def _start_mcp_server(self):

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -64,10 +64,17 @@ import inspect
 import os
 import time
 import warnings
+import weakref
 from typing import Any
 
 # Holder kept for backwards compatibility with older imports/tests.
 _active_mcp_thread = None
+
+# Weakref to the app that owns this process's MCP tool registry. Dash keys that
+# registry by tool name process-globally, so only one fast_dash app can own it;
+# a second mount raises rather than silently repointing both endpoints (#171).
+# A weakref means a garbage-collected app releases the slot on its own.
+_mcp_owner = None
 
 # Addresses that keep the (unauthenticated) /mcp route on this machine.
 LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1", "[::1]"})
@@ -778,13 +785,20 @@ def _describe_outputs(fd, state=None):
         if i < len(anns) and anns[i] in (str, int, float, bool, list, dict):
             jtype = _json_type_name(anns[i])
         cid = _stringify_id(comp.id)
-        entry = {"id": cid, "tag": tag, "type": jtype}
         # label_ is the label the UI actually renders: _infer_output_components
         # normalizes a wrong-length output_labels list to OUTPUT_1/OUTPUT_2 and
         # stamps it on the component, while fd.output_labels keeps the original.
-        label = getattr(comp, "label_", None)
-        if label:
-            entry["label"] = label
+        # The key is ALWAYS present (null when the component carries no label, as
+        # DynamicDash's runtime-built outputs don't): the documented contract is
+        # {id, tag, type, label}, and dropping the key made a generic agent that
+        # reads output["label"] raise KeyError on DynamicDash while working on
+        # FastDash. (issue #172)
+        entry = {
+            "id": cid,
+            "tag": tag,
+            "type": jtype,
+            "label": getattr(comp, "label_", None) or None,
+        }
         if state is not None and cid in state.outputs:
             entry["current_value"] = _summarize_for_history(state.outputs[cid])
         outputs.append(entry)
@@ -1000,6 +1014,25 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
 
     if getattr(fd, "_mcp_mounted", False):
         return
+
+    # Dash's `mcp_enabled` registry is process-global and keyed by tool name, so
+    # a second MCP-enabled app overwrites the first app's tools: BOTH /mcp
+    # endpoints -- including the first app's already-working one -- then resolve
+    # to whichever app registered last, and an agent driving app A silently runs
+    # app B's callback. That limitation was documented in prose but not enforced,
+    # so the collision was silent and active. Fail loudly instead. (issue #171)
+    global _mcp_owner
+    owner = _mcp_owner() if _mcp_owner is not None else None
+    if owner is not None and owner is not fd:
+        raise RuntimeError(
+            "mcp_server=True is already enabled on another app in this process "
+            f"({getattr(owner, 'title', None) or type(owner).__name__!r}). Dash's "
+            "MCP tool registry is process-global, so mounting a second one would "
+            "silently repoint BOTH /mcp endpoints at this app and an agent "
+            "driving the first app would run this app's callback instead. Run one "
+            "MCP-enabled app per process."
+        )
+    _mcp_owner = weakref.ref(fd)
     fd._mcp_mounted = True
 
     # Delegate the introspection surface to Dash; hide the noisy internal Dash
@@ -1017,6 +1050,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
     # of the input-mirror tools, then mount and return.
     if getattr(fd, "is_chat", False):
         _register_chat_mcp_tools(fd, mcp_enabled)
+        _override_mcp_instructions()
         enable_mcp_server(fd.app, mcp_path)
         if getattr(fd, "_backend", None):
             _install_asgi_mcp_request_context(fd.app.server, mcp_path)
@@ -1281,13 +1315,68 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             "outputs": _describe_outputs(fd, state),
         }
 
-    # Mount the MCP routes on the Dash app (same port).
+    # Mount the MCP routes on the Dash app (same port). Swap Dash's "stateless,
+    # does NOT update the browser" handshake instructions for ours first (#173).
+    _override_mcp_instructions()
     enable_mcp_server(fd.app, mcp_path)
 
     # On an ASGI backend, work around an upstream Dash 4.3 bug that breaks the
     # /mcp route (see _install_asgi_mcp_request_context).
     if getattr(fd, "_backend", None):
         _install_asgi_mcp_request_context(fd.app.server, mcp_path)
+
+
+_FASTDASH_MCP_INSTRUCTIONS = (
+    "This is a Fast Dash app: a Python callback rendered as a web UI, with a "
+    "live browser session a human may be watching.\n\n"
+    "Unlike a plain Dash app, this app's tools are STATEFUL -- they drive the "
+    "running app, and what you do IS reflected in the user's browser (within "
+    "about 500ms, no reload):\n"
+    "  - describe_app() -- start here: every input's id, type, default, allowed "
+    "options and current value, plus the outputs a run produces.\n"
+    "  - set_input(component_id, value) / set_inputs(inputs) -- set values; the "
+    "browser's widgets update to match.\n"
+    "  - invoke(inputs=None) -- set values and run the callback in one call; the "
+    "output renders in the browser and the result is returned to you.\n"
+    "  - set_form(specs) -- DynamicDash only: build the input form at runtime.\n\n"
+    "Values are validated against the contract describe_app() advertises, so you "
+    "cannot set something the UI itself could not produce."
+)
+
+
+def _override_mcp_instructions() -> None:
+    """Replace Dash's stateless ``initialize`` instructions with Fast Dash's.
+
+    Dash's native MCP server tells every connecting agent, in the very first
+    handshake, that "Dash apps are stateless ... calling a tool executes a
+    callback and returns its result to you, but does NOT update the user's
+    browser". For a Fast Dash app that is false and actively counter-productive:
+    the drive tools are precisely the stateful ones, and the ``instructions``
+    field exists to steer model behavior -- so an agent that trusts it is told
+    up front not to attempt the thing the feature exists for. (issue #173)
+
+    Dash builds its method table inside ``_process_mcp_message``, reading
+    ``_handle_initialize`` from module globals per call, so replacing the
+    attribute takes effect for every subsequent handshake. Best-effort: a Dash
+    version that restructures this leaves the stock instructions in place rather
+    than breaking the mount.
+    """
+    try:
+        from dash.mcp import _server as _dash_mcp_server
+
+        if getattr(_dash_mcp_server, "_fastdash_instructions_patched", False):
+            return
+        _stock_initialize = _dash_mcp_server._handle_initialize
+
+        def _fastdash_initialize():
+            result = _stock_initialize()
+            result.instructions = _FASTDASH_MCP_INSTRUCTIONS
+            return result
+
+        _dash_mcp_server._handle_initialize = _fastdash_initialize
+        _dash_mcp_server._fastdash_instructions_patched = True
+    except Exception:  # noqa: BLE001 - never fail the mount over instructions
+        pass
 
 
 def _install_asgi_mcp_request_context(server, mcp_path: str) -> None:

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -70,12 +70,20 @@ def _layout_ids(comp, out=None):
 
 @pytest.fixture(autouse=True)
 def clear_mcp_registry():
-    """Reset Dash's global MCP tool registry before each test (one app/process)."""
+    """Reset Dash's global MCP tool registry before each test (one app/process).
+
+    Also clears fast_dash's own one-owner-per-process latch (#171), which is
+    what enforces that limit at runtime: without resetting it, the *first* test
+    to mount an app would own the process and every later test would hit the
+    guard.
+    """
     try:
         from dash.mcp import _decorator
         _decorator.MCP_DECORATED_FUNCTIONS.clear()
     except Exception:
         pass
+    import fast_dash.mcp as _fd_mcp
+    _fd_mcp._mcp_owner = None
     yield
 
 
@@ -1215,3 +1223,125 @@ class TestMcpBugBatch:
         summary = next(iter(out["outputs"].values()))
         assert summary["type"] == "Image"
         assert "repr" not in summary
+
+
+class TestDogfoodBatchJul25:
+    """Regressions for the bugs the nightly dogfood filed against 0.6.5/0.6.6."""
+
+    def test_second_mcp_app_in_one_process_fails_loudly(self):
+        # #171: Dash's mcp_enabled registry is process-global, so a second
+        # MCP-enabled app silently overwrote the first's tools -- BOTH /mcp
+        # endpoints then drove the last-registered app, so an agent connected to
+        # app A was really running app B's callback. Documented in prose only.
+        def alpha(a: int = 1) -> int:
+            """ALPHA."""
+            return a + 100
+
+        def beta(b: int = 2) -> int:
+            """BETA."""
+            return b + 200
+
+        app1 = FastDash(callback_fn=alpha, mcp_server=True)
+        enable_mcp(app1)
+        app2 = FastDash(callback_fn=beta, mcp_server=True)
+        with pytest.raises(RuntimeError, match="already enabled on another app"):
+            enable_mcp(app2)
+
+    def test_same_app_remount_is_still_idempotent(self):
+        # The #171 guard must not break the documented per-app idempotency.
+        app = _plain_app()
+        enable_mcp(app)
+        enable_mcp(app)          # must not raise
+
+    def test_initialize_instructions_describe_stateful_drive(self):
+        # #173: the handshake served Dash's "Dash apps are stateless ... does NOT
+        # update the user's browser", telling every agent at connect time not to
+        # attempt the exact thing fast_dash's drive tools exist for.
+        c = _client_for(_plain_app())
+        instructions = _rpc(c, "initialize")["result"].get("instructions", "")
+        assert "does NOT update" not in instructions
+        assert "Fast Dash" in instructions
+        # It should point at the drive tools it actually ships.
+        for tool in ("describe_app", "set_input", "invoke"):
+            assert tool in instructions
+
+    def test_dynamicdash_outputs_always_carry_the_label_key(self):
+        # #172: the documented output contract is {id, tag, type, label}, but the
+        # key was dropped when the component had no label -- true for every
+        # DynamicDash output -- so a generic agent reading output["label"]
+        # worked on FastDash and raised KeyError on DynamicDash.
+        c = _client_for(_dynamic_app())
+        outputs = _call(c, "describe_app")["outputs"]
+        assert outputs, "DynamicDash must report its outputs (#160)"
+        for entry in outputs:
+            assert "label" in entry, f"missing label key: {entry}"
+
+    def test_fastdash_outputs_still_carry_their_label(self):
+        # The FastDash side of the same contract must keep its real label.
+        c = _client_for(_plain_app())
+        outputs = _call(c, "describe_app")["outputs"]
+        assert all("label" in e for e in outputs)
+
+
+def test_error_strings_are_ascii_only():
+    """#169: a non-ASCII char in a raised/warned message crashes cp1252 consoles.
+
+    The DynamicDash parent_control ValueError carried a U+2192 arrow (and an
+    em dash), so printing that traceback on a default Windows console raised a
+    secondary UnicodeEncodeError that masked the helpful message. Scan every
+    raise/warn literal in the package so the whole class stays fixed.
+    """
+    import ast
+    import pathlib
+
+    offenders = []
+    for path in sorted(pathlib.Path("fast_dash").rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in ast.walk(tree):
+            is_warn = (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "warn"
+            )
+            if not (isinstance(node, ast.Raise) or is_warn):
+                continue
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                    if any(ord(ch) > 127 for ch in sub.value):
+                        offenders.append(f"{path}:{sub.lineno}: {sub.value[:60]!r}")
+    assert not offenders, "non-ASCII error strings:\n" + "\n".join(offenders)
+
+
+@requires_fastapi
+def test_asgi_backend_announces_its_url(monkeypatch, capsys):
+    """#170: backend="fastapi" booted in total silence.
+
+    The Flask backend prints "Dash is running on <url>"; serving the ASGI app
+    object bypasses Dash's run() (which prints it) and uvicorn at
+    log_level="warning" says nothing either, so a user following the docs
+    ("Open the URL") had no URL and no way to tell a booted server from a hung
+    one.
+    """
+    import uvicorn
+
+    def fig(n: int = 3) -> go.Figure:
+        return go.Figure()
+
+    app = FastDash(callback_fn=fig, backend="fastapi", port=8091)
+
+    captured = {}
+
+    class _FakeServer:
+        def __init__(self, config):
+            captured["config"] = config
+
+        def run(self):
+            captured["ran"] = True
+
+    monkeypatch.setattr(uvicorn, "Server", _FakeServer)
+    app._run_asgi()
+
+    out = capsys.readouterr().out
+    assert "8091" in out and "http://" in out, f"no URL announced: {out!r}"
+    # uvicorn's own startup/shutdown lines are no longer suppressed.
+    assert captured["config"].log_level == "info"


### PR DESCRIPTION
Clears the entire open-bug board — the six findings the nightly dogfood filed against 0.6.5/0.6.6, batched because four of them are the same MCP-contract surface.

## 🔴 #171 — a second MCP app silently hijacked the first
Dash's `mcp_enabled` registry is process-global, so a second `mcp_server=True` app **overwrote** the first's tools: **both** `/mcp` endpoints then resolved to whichever registered last, and an agent connected to app A was silently reading and driving **app B's callback**. The one-app-per-process limit existed only as prose.

Now a module-level weakref latch raises a `RuntimeError` naming the owning app. Re-mounting the *same* app stays idempotent.

## #173 — the handshake told agents the opposite of what the app does
Every client read Dash's stock `initialize` instructions: *"Dash apps are stateless … does NOT update the user's browser."* For Fast Dash that's false — the drive tools are precisely the stateful ones — and `instructions` exists to steer model behavior, so agents were told at connect time not to attempt the feature's whole point. fast_dash now substitutes instructions describing the real drive surface.

## #172 — `describe_app` dropped `label` for DynamicDash outputs
The documented contract is `{id, tag, type, label}`, but the key was omitted whenever the component had no label — true for *every* DynamicDash output — so a generic agent reading `output["label"]` worked on FastDash and raised `KeyError` on DynamicDash. The key is now always present (`null` when unlabeled).

## #170 — `backend="fastapi"` started in total silence
Serving the ASGI app object bypasses Dash's `run()` (which prints the URL), and uvicorn was pinned to `log_level="warning"` — so the terminal was **empty**: no URL to open, no way to distinguish a booted server from a hung one. The URL is now announced and uvicorn's startup lines are restored.

## #169 — non-ASCII in a raised error
The `parent_control` `ValueError` carried `→` (U+2192) **and** an em dash (the issue only spotted the arrow), so printing that traceback on a cp1252 console raised a secondary `UnicodeEncodeError` that masked the message. Both replaced — and a test now scans **every** `raise`/`warn` literal in the package, so the whole class stays fixed rather than this one instance.

## #176 — docs vs reality on collection defaults
"10 minutes to Fast Dash" said `c: list = [1, 2, 3]` has "a default value of `[1, 2, 3]`", but a collection default builds the widget's *option set* and an untouched Run passes `None` — so a callback that works standalone crashes with `TypeError: 'NoneType' object is not iterable` on first Run. Documented what actually happens, plus the guard.

## Verification
Beyond unit tests, each behavioral claim was checked directly:
- **#169** — the message now round-trips through `.encode("cp1252")`.
- **#170** — a real ASGI boot: the log that was empty now shows `Dash is running on http://127.0.0.1:8087/` + uvicorn's lines, and `GET /` → 200.
- **#171/#172/#173** — over the `/mcp` wire (second mount raises; every output entry carries `label`; instructions no longer say "does NOT update").

## Tests
7 new (incl. the package-wide ASCII scanner and the idempotency guard). **408 passed** across the non-browser suites; Selenium runs in CI.

Also fixes a latent test-isolation gap the new guard exposed: `clear_mcp_registry` now resets fast_dash's owner latch too, or the first test to mount would own the process and every later one would trip #171.

Closes #169, #170, #171, #172, #173, #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)
