### PR TITLE
feat: drag to resize the input sidebar (#80)

### DIFF
--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -835,6 +835,28 @@ class AppLayout:
                    "display": "flex", "flexDirection": "column"},
         )
 
+    @staticmethod
+    def _sidebar_resizer():
+        """Grab strip on the sidebar's trailing edge (issue #80).
+
+        The drag itself is clientside (``assets/fd_sidebar_resize.js``): it
+        writes Mantine's ``--app-shell-navbar-width`` / ``-offset`` vars, which
+        move the sidebar and the output pane together, capped at half the
+        viewport. Exposed as a real slider role so it is reachable by keyboard
+        and announced, not just draggable.
+        """
+        return html.Div(
+            id="fd-sidebar-resizer",
+            className="fd-sidebar-resizer",
+            role="separator",
+            tabIndex=0,
+            title="Drag to resize the sidebar",
+            **{
+                "aria-orientation": "vertical",
+                "aria-label": "Resize sidebar",
+            },
+        )
+
     def generate_layout(self, stream_event_names=None):
         if self.minimal:
             self.title = self.subtitle = self.navbar = self.footer = False
@@ -842,6 +864,15 @@ class AppLayout:
         header_children = self.generate_navbar_container() or []
         navbar_content = self.generate_input_component()
         main_content = self.generate_output_component()
+        # generate_input_component returns a *list* of sections; keep the navbar
+        # children flat (Dash does not flatten a nested list, and a nested one
+        # silently drops the sections inside it) when appending the resize
+        # handle (issue #80).
+        navbar_children = (
+            list(navbar_content)
+            if isinstance(navbar_content, (list, tuple))
+            else [navbar_content]
+        ) + [self._sidebar_resizer()]
 
         has_sidecar = getattr(self.app, "has_chat_sidecar", False)
         # A chat sidecar is stacked under the inputs in the navbar (built by
@@ -857,7 +888,7 @@ class AppLayout:
                 id="header1162572",
             ),
             dmc.AppShellNavbar(
-                navbar_content,
+                navbar_children,
                 p="md",
                 id="navbar3260780",
                 # Column so the grow inputs-section scrolls and the Run
@@ -897,6 +928,11 @@ class AppLayout:
         extra = [
             dmc.NotificationContainer(id="notification-container"),
             html.Div(id="dummy-div", style={"display": "none"}),
+            # Dragged sidebar width (issue #80). The drag applies instantly via
+            # CSS vars; this store is what makes it survive a collapse/expand,
+            # since toggle_sidebar re-renders the shell from the navbar prop and
+            # would otherwise snap the width back to the default.
+            dcc.Store(id="fd-sidebar-width"),
         ]
         # About modal
         if self.about and header_children and len(header_children) > 1:
@@ -1078,7 +1114,10 @@ class AppLayout:
             appshell_children.insert(
                 1,
                 dmc.AppShellNavbar(
-                    self.generate_input_component(collapsible=True),
+                    # Flat children: generate_input_component returns a list and
+                    # Dash does not flatten a nested one (issue #80).
+                    [*self.generate_input_component(collapsible=True),
+                     self._sidebar_resizer()],
                     p="md",
                     id="navbar3260780",
                     style={"display": "flex", "flexDirection": "column",
@@ -1096,6 +1135,7 @@ class AppLayout:
         extra = [
             dmc.NotificationContainer(id="notification-container"),
             html.Div(id="dummy-div", style={"display": "none"}),
+            dcc.Store(id="fd-sidebar-width"),     # dragged width (issue #80)
             *self._chat_stores(),                 # chat state stores (shared)
         ]
         if self.about and header_children and len(header_children) > 1:
@@ -1130,8 +1170,9 @@ class AppLayout:
         @app.app.callback(
             Output("appshell", "navbar"),
             Input("sidebar-button", "opened"),
+            State("fd-sidebar-width", "data"),
         )
-        def toggle_sidebar(opened):
+        def toggle_sidebar(opened, dragged_width):
             user_agent = request.headers.get("User-Agent")
 
             # A chat sidecar stacks the chat under the inputs and needs the wider
@@ -1149,9 +1190,16 @@ class AppLayout:
             # The sidecar width (420) must match generate_layout's, or dmc
             # derives the main offset and collapse-transform from the wrong width
             # -- leaving the output shifted under the sidebar and the sidebar
-            # unable to fully close (v0.5.5 / #143).
+            # unable to fully close (v0.5.5 / #143). A width the user dragged to
+            # (issue #80) wins over that default: this callback re-renders the
+            # shell from the navbar prop, so returning the default here would
+            # snap a resized sidebar back on the next collapse/expand.
+            width = 420 if has_sidecar else 300
+            if isinstance(dragged_width, (int, float)) and dragged_width > 0:
+                width = int(dragged_width)
+
             return {
-                "width": 420 if has_sidecar else 300,
+                "width": width,
                 "breakpoint": "sm",
                 "collapsed": collapsed,
             }

--- a/fast_dash/assets/fast_dash.css
+++ b/fast_dash/assets/fast_dash.css
@@ -418,3 +418,59 @@
   font-style: italic;
   text-align: center;
 }
+
+/* --- Draggable sidebar width (issue #80) -------------------------------------
+   A grab strip on the sidebar's trailing edge. It sits inside the navbar (which
+   AppShell positions), so `inset-inline-end: 0` pins it to that edge in both LTR
+   and RTL. Kept narrow but with a generous hit area, and invisible until you
+   approach it so it doesn't add a permanent line to the chrome. */
+.fd-sidebar-resizer {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  width: 8px;
+  cursor: col-resize;
+  z-index: 5;
+  /* The visible hairline is a child pseudo-element so the grab area can stay
+     wider than the 1px people actually see. */
+  background: transparent;
+  transition: background 120ms ease;
+}
+
+.fd-sidebar-resizer::after {
+  content: "";
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  width: 2px;
+  background: transparent;
+  transition: background 120ms ease;
+}
+
+.fd-sidebar-resizer:hover::after,
+.fd-sidebar-resizer:focus-visible::after,
+body.fd-resizing .fd-sidebar-resizer::after {
+  background: var(--mantine-color-default-border);
+}
+
+.fd-sidebar-resizer:focus-visible {
+  outline: 2px solid var(--mantine-primary-color-filled);
+  outline-offset: -2px;
+}
+
+/* While dragging: kill the text-selection ghosting and any width transition so
+   the sidebar tracks the pointer exactly. */
+body.fd-resizing {
+  user-select: none;
+  cursor: col-resize;
+}
+
+body.fd-resizing * {
+  transition: none !important;
+}
+
+/* Below the AppShell breakpoint the navbar goes full-width and becomes an
+   overlay, so there is no edge to drag. */
+@media (max-width: 768px) {
+  .fd-sidebar-resizer { display: none; }
+}

--- a/fast_dash/assets/fd_sidebar_resize.js
+++ b/fast_dash/assets/fd_sidebar_resize.js
@@ -1,0 +1,127 @@
+/* Fast Dash: drag-to-resize the input sidebar (progressive, no-op without it).
+
+   Mantine's AppShell drives BOTH the navbar's own width and the main pane's
+   offset from two CSS variables it writes inline on the shell
+   (`--app-shell-navbar-width` / `--app-shell-navbar-offset`), and it builds the
+   collapse transform out of the width var too. So setting those two vars during
+   a drag moves the sidebar, shifts the output pane with it, and keeps the
+   collapse animation correct -- no server round-trip, no layout thrash.
+
+   dmc recomputes those vars from the `navbar` prop whenever the shell
+   re-renders (the toggle callback returns a fresh dict), which would snap a
+   dragged sidebar back to its default. On release we therefore persist the
+   width into a dcc.Store that the toggle callback reads back, so the width
+   survives a collapse/expand cycle. */
+(function () {
+  var MIN_WIDTH = 200;                 // narrower than this and controls clip
+  var MAX_FRACTION = 0.5;              // issue #80: at most half the screen
+  var SHELL_ID = "appshell";
+  var STORE_ID = "fd-sidebar-width";
+
+  function maxWidth() {
+    return Math.round(window.innerWidth * MAX_FRACTION);
+  }
+
+  function clampWidth(px) {
+    return Math.max(MIN_WIDTH, Math.min(px, maxWidth()));
+  }
+
+  function applyWidth(shell, px) {
+    // Width drives the navbar box AND (via calc) the collapse transform;
+    // offset drives the main pane. Both must move together or the output
+    // ends up shifted under the sidebar.
+    shell.style.setProperty("--app-shell-navbar-width", px + "px");
+    shell.style.setProperty("--app-shell-navbar-offset", px + "px");
+  }
+
+  function persistWidth(px) {
+    // Let the server-side toggle callback reuse this width instead of the
+    // hardcoded default the next time it re-renders the shell.
+    try {
+      if (window.dash_clientside && window.dash_clientside.set_props) {
+        window.dash_clientside.set_props(STORE_ID, { data: px });
+      }
+    } catch (e) { /* persistence is best-effort; the drag still applied */ }
+  }
+
+  function startDrag(handle, ev) {
+    var shell = document.getElementById(SHELL_ID);
+    if (!shell) { return; }
+    // Below the breakpoint the navbar is full-width and dragging is meaningless
+    // (CSS hides the handle there too; this is the belt-and-braces check).
+    if (window.innerWidth <= 768) { return; }
+
+    ev.preventDefault();
+    document.body.classList.add("fd-resizing");
+
+    var shellLeft = shell.getBoundingClientRect().left;
+
+    function onMove(e) {
+      var px = clampWidth(Math.round(e.clientX - shellLeft));
+      applyWidth(shell, px);
+      handle.setAttribute("aria-valuenow", String(px));
+    }
+
+    function onUp() {
+      document.body.classList.remove("fd-resizing");
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      var current = parseInt(
+        shell.style.getPropertyValue("--app-shell-navbar-width"), 10);
+      if (!isNaN(current)) { persistWidth(current); }
+    }
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+  }
+
+  function wire(handle) {
+    if (handle.getAttribute("data-fd-resize")) { return; }
+    handle.setAttribute("data-fd-resize", "1");
+    handle.addEventListener("pointerdown", function (ev) { startDrag(handle, ev); });
+
+    // Keyboard access: the handle is focusable, so arrows nudge it and the
+    // sidebar stays operable without a pointer.
+    handle.addEventListener("keydown", function (ev) {
+      var step = ev.shiftKey ? 50 : 10;
+      var delta = ev.key === "ArrowLeft" ? -step : ev.key === "ArrowRight" ? step : 0;
+      if (!delta) { return; }
+      var shell = document.getElementById(SHELL_ID);
+      if (!shell) { return; }
+      ev.preventDefault();
+      var now = parseInt(
+        shell.style.getPropertyValue("--app-shell-navbar-width"), 10) || MIN_WIDTH;
+      var px = clampWidth(now + delta);
+      applyWidth(shell, px);
+      handle.setAttribute("aria-valuenow", String(px));
+      persistWidth(px);
+    });
+  }
+
+  function scan() {
+    document.querySelectorAll(".fd-sidebar-resizer").forEach(wire);
+  }
+
+  // The handle arrives with Dash's first render and again after any re-render
+  // that replaces the navbar, so keep watching rather than wiring once.
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", scan);
+  } else {
+    scan();
+  }
+  new MutationObserver(scan).observe(document.documentElement, {
+    childList: true, subtree: true,
+  });
+
+  // A resize that shrinks the viewport can leave the sidebar wider than the
+  // 50% cap, so re-clamp against the new viewport.
+  window.addEventListener("resize", function () {
+    var shell = document.getElementById(SHELL_ID);
+    if (!shell) { return; }
+    var now = parseInt(
+      shell.style.getPropertyValue("--app-shell-navbar-width"), 10);
+    if (isNaN(now)) { return; }
+    var px = clampWidth(now);
+    if (px !== now) { applyWidth(shell, px); persistWidth(px); }
+  });
+})();

--- a/fast_dash/assets/fd_sidebar_resize.js
+++ b/fast_dash/assets/fd_sidebar_resize.js
@@ -1,11 +1,15 @@
 /* Fast Dash: drag-to-resize the input sidebar (progressive, no-op without it).
 
    Mantine's AppShell drives BOTH the navbar's own width and the main pane's
-   offset from two CSS variables it writes inline on the shell
-   (`--app-shell-navbar-width` / `--app-shell-navbar-offset`), and it builds the
-   collapse transform out of the width var too. So setting those two vars during
-   a drag moves the sidebar, shifts the output pane with it, and keeps the
-   collapse animation correct -- no server round-trip, no layout thrash.
+   offset from two CSS variables (`--app-shell-navbar-width` /
+   `--app-shell-navbar-offset`), and it builds the collapse transform out of the
+   width var too. Setting those two as inline styles on the shell therefore
+   moves the sidebar, shifts the output pane with it, and keeps the collapse
+   animation correct -- no server round-trip, no layout thrash.
+
+   Note dmc's own values are rem expressions (`calc(18.75rem * 1)`) supplied by
+   a stylesheet, not inline pixels, so the current width is always MEASURED off
+   the rendered navbar rather than parsed out of the variable.
 
    dmc recomputes those vars from the `navbar` prop whenever the shell
    re-renders (the toggle callback returns a fresh dict), which would snap a
@@ -24,6 +28,23 @@
 
   function clampWidth(px) {
     return Math.max(MIN_WIDTH, Math.min(px, maxWidth()));
+  }
+
+  function navbarEl() {
+    // The handle is appended as a direct child of the navbar, so its parent is
+    // the element whose width we are changing.
+    var handle = document.querySelector(".fd-sidebar-resizer");
+    return handle ? handle.parentElement : null;
+  }
+
+  function currentWidth() {
+    // Measure the rendered box rather than parsing the CSS var: dmc expresses
+    // the var in rem (`calc(18.75rem * 1)`), which no amount of parseInt turns
+    // into pixels -- reading it that way made the keyboard nudge either jump to
+    // the minimum or do nothing at all. getBoundingClientRect is always px and
+    // is true regardless of how the width was set.
+    var nav = navbarEl();
+    return nav ? Math.round(nav.getBoundingClientRect().width) : null;
   }
 
   function applyWidth(shell, px) {
@@ -66,9 +87,8 @@
       document.body.classList.remove("fd-resizing");
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
-      var current = parseInt(
-        shell.style.getPropertyValue("--app-shell-navbar-width"), 10);
-      if (!isNaN(current)) { persistWidth(current); }
+      var current = currentWidth();
+      if (current !== null) { persistWidth(current); }
     }
 
     window.addEventListener("pointermove", onMove);
@@ -89,8 +109,8 @@
       var shell = document.getElementById(SHELL_ID);
       if (!shell) { return; }
       ev.preventDefault();
-      var now = parseInt(
-        shell.style.getPropertyValue("--app-shell-navbar-width"), 10) || MIN_WIDTH;
+      var now = currentWidth();
+      if (now === null) { return; }
       var px = clampWidth(now + delta);
       applyWidth(shell, px);
       handle.setAttribute("aria-valuenow", String(px));
@@ -118,9 +138,8 @@
   window.addEventListener("resize", function () {
     var shell = document.getElementById(SHELL_ID);
     if (!shell) { return; }
-    var now = parseInt(
-      shell.style.getPropertyValue("--app-shell-navbar-width"), 10);
-    if (isNaN(now)) { return; }
+    var now = currentWidth();
+    if (now === null) { return; }
     var px = clampWidth(now);
     if (px !== now) { applyWidth(shell, px); persistWidth(px); }
   });

--- a/tests/test_sidebar_resize.py
+++ b/tests/test_sidebar_resize.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python
+"""Draggable input sidebar (issue #80).
+
+The drag itself is clientside (assets/fd_sidebar_resize.js writes Mantine's
+AppShell CSS vars), so these cover the parts Python owns: the handle and store
+are in the layout, and the width a user dragged to survives the collapse/expand
+callback that re-renders the shell.
+"""
+import json
+
+from fast_dash import FastDash
+
+
+def _ids(component, out=None):
+    out = set() if out is None else out
+    cid = getattr(component, "id", None)
+    if isinstance(cid, str):
+        out.add(cid)
+    children = getattr(component, "children", None)
+    for child in (
+        children if isinstance(children, (list, tuple))
+        else [children] if children is not None else []
+    ):
+        if child is not None:
+            _ids(child, out)
+    return out
+
+
+def _app():
+    def f(x: str = "hi") -> str:
+        """Echo."""
+        return x
+
+    return FastDash(callback_fn=f)
+
+
+def _toggle(app, opened, width):
+    """Drive the real toggle_sidebar callback over Dash's update wire."""
+    client = app.app.server.test_client()
+    payload = {
+        "output": "appshell.navbar",
+        "outputs": {"id": "appshell", "property": "navbar"},
+        "inputs": [{"id": "sidebar-button", "property": "opened", "value": opened}],
+        "state": [{"id": "fd-sidebar-width", "property": "data", "value": width}],
+        "changedPropIds": ["sidebar-button.opened"],
+    }
+    r = client.post(
+        "/_dash-update-component",
+        data=json.dumps(payload),
+        headers={"Content-Type": "application/json"},
+    )
+    return (r.get_json() or {})["response"]["appshell"]["navbar"]
+
+
+def test_sidebar_layout_has_resize_handle_and_store():
+    ids = _ids(_app().app.layout)
+    assert "fd-sidebar-resizer" in ids
+    assert "fd-sidebar-width" in ids
+
+
+def test_chat_layout_has_resize_handle():
+    from fast_dash import Chat
+
+    def chat_fn(query: str, temperature: float = 0.5) -> Chat:
+        """Chat."""
+        return {"query": query, "response": "hi"}
+
+    ids = _ids(FastDash(callback_fn=chat_fn, chat=True).app.layout)
+    assert "fd-sidebar-resizer" in ids
+    assert "fd-sidebar-width" in ids
+
+
+def test_toggle_keeps_the_default_width_when_never_dragged():
+    assert _toggle(_app(), True, None)["width"] == 300
+
+
+def test_toggle_preserves_a_dragged_width():
+    # Regression: toggle_sidebar re-renders the shell from the navbar prop, so
+    # returning the hardcoded default snapped a resized sidebar back to 300 on
+    # the next collapse/expand.
+    assert _toggle(_app(), True, 640)["width"] == 640
+
+
+def test_dragged_width_survives_a_collapse_expand_cycle():
+    app = _app()
+    assert _toggle(app, False, 640)["width"] == 640     # collapsed
+    assert _toggle(app, True, 640)["width"] == 640      # re-expanded
+
+
+def test_bogus_stored_width_falls_back_to_the_default():
+    for junk in ("wide", 0, -50, None):
+        assert _toggle(_app(), True, junk)["width"] == 300
+
+
+def test_resizer_handle_is_keyboard_reachable():
+    handle = next(
+        c for c in _walk(_app().app.layout)
+        if getattr(c, "id", None) == "fd-sidebar-resizer"
+    )
+    assert handle.tabIndex == 0
+    assert handle.role == "separator"
+
+
+def _walk(component):
+    yield component
+    children = getattr(component, "children", None)
+    for child in (
+        children if isinstance(children, (list, tuple))
+        else [children] if children is not None else []
+    ):
+        if child is not None:
+            yield from _walk(child)
+
+
+def test_drag_script_caps_width_at_half_the_viewport():
+    """Issue #80 asks for 'up to 50% of the width of the screen'."""
+    js = (
+        __import__("pathlib").Path("fast_dash/assets/fd_sidebar_resize.js")
+        .read_text(encoding="utf-8")
+    )
+    assert "MAX_FRACTION = 0.5" in js
+    # Both vars must move together or the output pane stays put while the
+    # sidebar grows, leaving the content shifted under it.
+    assert "--app-shell-navbar-width" in js
+    assert "--app-shell-navbar-offset" in js


### PR DESCRIPTION
Closes #80 — *"Users should be able to drag along the width of the input component sidebar in the sidebar layout up to 50% of the width of the screen."*

Adds a grab strip on the sidebar's trailing edge. Drag it to resize the input sidebar, capped at **half the viewport** as the issue asks.

## How it works
Mantine's AppShell drives **both** the navbar box and the main pane's offset from two CSS variables it writes inline on the shell (`--app-shell-navbar-width` / `--app-shell-navbar-offset`), and it builds the collapse transform out of the width var. The drag writes those two vars, so:

- the sidebar and the **output pane move together** (writing only the width would grow the sidebar *over* the content),
- the collapse animation stays correct for free,
- and there's no server round-trip while dragging — it tracks the pointer.

## The persistence problem this had to solve
dmc recomputes those vars from the `navbar` prop on every shell re-render, and `toggle_sidebar` returns a fresh dict on each collapse/expand — which would **snap a resized sidebar back to the default**. So on release the width is persisted into a `dcc.Store` that `toggle_sidebar` now reads back. This is the same "width lives in two places" constraint as v0.5.5 / #143. A missing or nonsensical stored value falls back to the default.

## Details
- **Keyboard operable**: the handle is focusable with `role="separator"`; arrow keys nudge it (shift = coarser step), so resizing isn't pointer-only.
- **Hidden below the breakpoint**, where the navbar becomes a full-width overlay with no edge to drag.
- Min width 200px so controls don't clip; max 50vw. Re-clamps if the viewport shrinks.
- Handle is invisible until hover/focus, so it adds no permanent line to the chrome.

## A bug this surfaced
`generate_input_component()` returns a **list**, and Dash does not flatten a nested list in `children` — so naively appending the handle as `[navbar_content, handle]` silently **dropped the chat sidecar's components**. Caught by `test_chat` (4 failures) and fixed by flattening the navbar children in both layouts.

## Tests
New `tests/test_sidebar_resize.py` (8): handle + store present in both the sidebar and chat layouts, the default width when never dragged, a dragged width preserved, survival across a collapse/expand cycle, bogus-value fallback, keyboard reachability, and the 50%-cap contract in the drag script. Driven through the **real** `toggle_sidebar` callback over Dash's update wire, not by calling the function directly.

**426 passed** across the non-browser suites; Selenium runs in CI.

## What I could not verify here
The drag interaction itself is clientside and needs a real browser — Playwright isn't available in this environment, so I verified the wiring, the persistence over Dash's update wire, and the CSS/JS contracts, but **not** the visual feel of dragging. Worth a quick manual check before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
