### PR TITLE
fix: honour Enum/date input hints, render update_live apps for every visitor (#181, #182, #183)

### DIFF
--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -1264,13 +1264,16 @@ def _resolve_typing_hint(hint, default_value=None):
     if isinstance(hint, type) and issubclass(hint, enum.Enum):
         members = [str(e.value) for e in hint]
         default = str(default_value.value) if isinstance(default_value, enum.Enum) else members[0] if members else None
-        return _ResolvedHint(
-            component=Fastify(
-                dmc.Select(data=members, value=default),
-                "value",
-                tag="Enum",
-            ),
+        component = Fastify(
+            dmc.Select(data=members, value=default),
+            "value",
+            tag="Enum",
         )
+        # Remember the Enum class: the widget can only carry the option string,
+        # but the callback's type hint promises the *member*, so the transform
+        # layer needs the class to map "red" back to Color.RED (issue #181).
+        component.enum_class = hint
+        return _ResolvedHint(component=component)
 
     # Annotated[T, metadata] -> depends on metadata
     if origin is Annotated:

--- a/fast_dash/chat_app.py
+++ b/fast_dash/chat_app.py
@@ -333,7 +333,7 @@ class ChatAppMixin:
         """
         from .utils import _transform_inputs, _transform_outputs
         raw = [drive_inputs.get(n) for n in self._chat_input_names]
-        inputs = _transform_inputs(raw, self.input_tags)
+        inputs = _transform_inputs(raw, self.input_tags, self.inputs_with_ids)
         # Serialize against a user's manual Run (A4): one host-callback execution
         # at a time across the Run thread and this chat thread.
         lock = getattr(self, "_host_callback_lock", None)

--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -833,9 +833,13 @@ class FastDash(ChatAppMixin):
         self.submit_clicks = 0
         self.reset_clicks = 0
         self.app_initialized = False
-        # True once the page-load render of the main callback has run; a later
-        # no-trigger fire is a re-mount re-fire and must not clobber (Bug 1b).
-        self._initial_render_done = False
+        # One-shot: armed only when a Run swaps output-group-col.children, which
+        # makes Dash re-fire the main callback with an empty ctx. The next
+        # no-trigger fire consumes it and yields no_update so that expected
+        # re-fire can't clobber the Run's outputs (Bug 1b). Deliberately NOT a
+        # permanent latch -- as one it made the page-load render happen once per
+        # worker process, blanking every visitor after the first (issue #183).
+        self._expect_remount_refire = False
 
 
     def _init_multi_function(self):
@@ -1264,7 +1268,8 @@ class FastDash(ChatAppMixin):
             user_input_vals = list(input_values[
                 input_offset:input_offset + len(sd["inputs_with_ids"])
             ])
-            user_input_vals = _transform_inputs(user_input_vals, sd["input_tags"])
+            user_input_vals = _transform_inputs(user_input_vals, sd["input_tags"],
+                                                sd["inputs_with_ids"])
             for (pname, _pobj), val in zip(sd["user_params"], user_input_vals):
                 kwargs[pname] = val
 
@@ -2003,30 +2008,36 @@ class FastDash(ChatAppMixin):
                 # clobber the value a genuine Run just rendered. A true no-trigger
                 # fire (page load) still raises as before.
                 if _tid in ("submit_inputs", "reset_inputs"):
-                    self._initial_render_done = True
                     return _no_update_all()
                 raise PreventUpdate
 
-            # No genuine trigger (update_live app): the FIRST such call is the
-            # real page-load render (it must establish the default output view);
-            # any later no-trigger call is a re-mount re-fire -- e.g. the
-            # Run-reset swapping output-group-col.children remounts the leaf
-            # outputs and re-fires this callback with an empty ctx. Returning the
-            # default output there would clobber the value the Run just rendered,
-            # so after the first render a no-trigger call yields no_update.
+            # No genuine trigger (update_live app): normally the real page-load
+            # render, which must establish the output view. The exception is the
+            # re-mount re-fire that follows a Run-reset swapping
+            # output-group-col.children -- that remounts the leaf outputs and
+            # re-fires this callback with an empty ctx, where returning defaults
+            # would clobber what the Run just rendered.
+            #
+            # That expected re-fire is announced by a ONE-SHOT token set at the
+            # single place that swaps children, and consumed here. It used to be
+            # a permanent `_initial_render_done` latch on the instance, which
+            # made the page-load render happen once per worker *process* instead
+            # of once per page load: the first visitor got a dashboard and every
+            # later visitor (or reload) got a blank one, silently (issue #183).
             if not genuine_trigger:
-                if getattr(self, "_initial_render_done", False):
-                    # no_update for every output component (+ notification +
-                    # overlay), so this re-mount re-fire leaves the values a
-                    # genuine Run / drive already rendered untouched.
+                if getattr(self, "_expect_remount_refire", False):
+                    # Consume the token: no_update for every output component
+                    # (+ notification + overlay) leaves the values the Run
+                    # already rendered untouched.
+                    self._expect_remount_refire = False
                     return _no_update_all()
-                self._initial_render_done = True
 
             default_notification = []
             self.state_counter += 1
 
             try:
-                inputs = _transform_inputs(input_args, self.input_tags)
+                inputs = _transform_inputs(input_args, self.input_tags,
+                                            self.inputs_with_ids)
 
                 if ctx.triggered_id == "submit_inputs" or (
                     self.update_live is True and None not in input_args
@@ -2078,6 +2089,13 @@ class FastDash(ChatAppMixin):
                     if _run_reset_server and _layout_dirty:
                         try:
                             children = self._run_reset_children(self.output_state)
+                            # Swapping children remounts the leaves, which makes
+                            # Dash re-fire this callback with an empty ctx. Arm
+                            # the one-shot token so that expected re-fire is
+                            # ignored instead of clobbering these outputs -- and
+                            # so that ordinary page loads, which never set it,
+                            # still render (issue #183).
+                            self._expect_remount_refire = True
                             return (self.output_state
                                     + [default_notification, False]
                                     + _extra(children=children, dirty=False))
@@ -2370,7 +2388,8 @@ class FastDash(ChatAppMixin):
 
             try:
                 num_extra = 3 if self.stream else 2
-                inputs = _transform_inputs(args[:-num_extra], _fd["input_tags"])
+                inputs = _transform_inputs(args[:-num_extra], _fd["input_tags"],
+                                            _fd["inputs_with_ids"])
 
                 if ctx.triggered_id == submit_id or (
                     _fd["update_live"] is True and None not in args

--- a/fast_dash/utils.py
+++ b/fast_dash/utils.py
@@ -3,6 +3,7 @@ Utility functions
 """
 import base64
 import copy
+import datetime
 import functools
 import inspect
 from io import BytesIO
@@ -799,16 +800,71 @@ def _transform_outputs(output_states, tags, outputs_with_ids, counter):
     ]
 
 
-def _transform_inputs(inputs, tags):
-    "Transform inputs to fit in the desired components"
+def _coerce_enum(value, component):
+    """Map a Select's option string back to the Enum member (issue #181).
 
+    A widget can only carry the stringified option, but typing a parameter as an
+    ``enum.Enum`` is exactly how you ask to receive the *member* -- so handing
+    the callback ``"red"`` made ``.value``/``.name`` raise and, worse, made
+    ``color is Color.RED`` quietly never match. The class is stashed on the
+    component when the dropdown is built.
+    """
+    enum_class = getattr(component, "enum_class", None)
+    if enum_class is None or isinstance(value, enum_class):
+        return value
+    for member in enum_class:
+        if value == member or str(member.value) == str(value):
+            return member
+    return value                      # unknown option: hand it back untouched
+
+
+def _coerce_date(value, tag):
+    """Parse a picker's ISO string into date/datetime (issue #182).
+
+    The untouched default arrives as a real ``datetime.date`` while a *set*
+    value arrives as ``"2025-12-25"``, so an app worked until someone touched
+    the picker and then crashed on ``.isoformat()``/``.year``. Normalize both
+    paths to the type the hint promises.
+    """
+    if not isinstance(value, str):
+        return value                  # already a date/datetime -- leave it
+    text = value.strip()
+    if not text:
+        return value
+    try:
+        if tag == "Timestamp":
+            return datetime.datetime.fromisoformat(text)
+        # A date picker may still hand back a full ISO timestamp; keep the date.
+        try:
+            return datetime.date.fromisoformat(text)
+        except ValueError:
+            return datetime.datetime.fromisoformat(text).date()
+    except (ValueError, TypeError):
+        return value                  # unparseable: don't mangle the input
+
+
+def _transform_inputs(inputs, tags, components=None):
+    """Transform inputs to fit in the desired components.
+
+    ``components`` (the ``inputs_with_ids`` aligned to ``inputs``) is optional so
+    older call sites keep working, but without it Enum inputs can't be mapped
+    back to their member -- the Enum class lives on the component.
+    """
+    comps = list(components) if components else []
     transformed_inputs = []
-    for inp, tag in zip(inputs, tags):
+    for i, (inp, tag) in enumerate(zip(inputs, tags)):
+        comp = comps[i] if i < len(comps) else None
         if inp is None:
             transformed_inputs.append(inp)
 
         elif tag == "Image":
             transformed_inputs.append(_b64_to_pil(inp))
+
+        elif tag == "Enum":
+            transformed_inputs.append(_coerce_enum(inp, comp))
+
+        elif tag in ("Date", "Timestamp"):
+            transformed_inputs.append(_coerce_date(inp, tag))
 
         else:
             transformed_inputs.append(inp)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -2072,9 +2072,14 @@ class TestMainCallbackNoTriggerNeutralized:
             fdmod.ctx = orig
 
     def test_remount_refire_returns_no_update_for_update_live(self):
-        # An update_live app renders defaults ONCE (page load) then yields
-        # no_update on every later no-trigger fire, so a Run-reset re-mount
-        # cannot revert the value the Run just rendered.
+        # An update_live app renders on EVERY page load, and yields no_update
+        # only for the re-mount re-fire that a children-swapping Run announces
+        # via the one-shot token.
+        #
+        # This used to be a permanent latch: the first no-trigger fire rendered
+        # and every later one returned no_update. That made the page-load render
+        # happen once per worker *process*, so the first visitor got a dashboard
+        # and everyone after got a blank one (issue #183).
         import dash
         import fast_dash.fast_dash as fdmod
         from fast_dash import Text
@@ -2087,11 +2092,22 @@ class TestMainCallbackNoTriggerNeutralized:
         orig = fdmod.ctx
         fdmod.ctx = _FakeCtx(None)
         try:
-            app._initial_render_done = False
-            first = raw(1, 2, 0, 0, "sid-a")           # page-load render
+            first = raw(1, 2, 0, 0, "sid-a")           # page load -> renders
             assert not all(x is dash.no_update for x in first)
-            second = raw(1, 2, 0, 0, "sid-a")          # re-mount re-fire
-            assert all(x is dash.no_update for x in second)
+
+            # A SECOND page load must render too -- this is the #183 regression.
+            second = raw(1, 2, 0, 0, "sid-a")
+            assert not all(x is dash.no_update for x in second)
+
+            # Arm the token the way a children-swapping Run does: that one
+            # expected re-fire must not clobber what the Run just rendered.
+            app._expect_remount_refire = True
+            refire = raw(1, 2, 0, 0, "sid-a")
+            assert all(x is dash.no_update for x in refire)
+
+            # ...and it is one-shot, so the next page load renders again.
+            after = raw(1, 2, 0, 0, "sid-a")
+            assert not all(x is dash.no_update for x in after)
         finally:
             fdmod.ctx = orig
 
@@ -2109,7 +2125,7 @@ class TestMainCallbackNoTriggerNeutralized:
         orig = fdmod.ctx
         fdmod.ctx = _FakeCtx("submit_inputs")
         try:
-            app._initial_render_done = True            # past page load
+            # (no render latch any more -- a genuine submit always runs)
             out = raw(7, 0, 1, "sid-a")                # a, reset, submit, sid
             assert out[0] == "value-7"
         finally:
@@ -2131,7 +2147,6 @@ class TestMainCallbackNoTriggerNeutralized:
         orig = fdmod.ctx
         fdmod.ctx = _FakeCtx("reset_inputs")
         try:
-            app._initial_render_done = True
             # a, b, reset_n=0 (phantom -- remounted), submit_n=4, sid.
             out = raw(1, 2, 0, 4, "sid-a")
             assert all(x is dash.no_update for x in out)
@@ -2149,7 +2164,6 @@ class TestMainCallbackNoTriggerNeutralized:
         orig = fdmod.ctx
         fdmod.ctx = _FakeCtx("submit_inputs")
         try:
-            app._initial_render_done = True
             out = raw(1, 2, 0, 0, "sid-a")             # submit_n=0 -> phantom
             assert all(x is dash.no_update for x in out)
         finally:
@@ -2166,7 +2180,6 @@ class TestMainCallbackNoTriggerNeutralized:
         orig = fdmod.ctx
         fdmod.ctx = _FakeCtx("reset_inputs")
         try:
-            app._initial_render_done = True
             out = raw(1, 2, 1, 0, "sid-a")             # reset_n=1 -> genuine
             # Not a no_update sweep: the reset branch returned real defaults.
             assert not all(x is dash.no_update for x in out)
@@ -2186,7 +2199,6 @@ class TestManualRunMirror:
         orig = fdmod.ctx
         fdmod.ctx = _FakeCtx("submit_inputs")
         try:
-            app._initial_render_done = True
             raw(3, 4, 0, 1, "sid-run")                 # a, b, reset, submit, sid
         finally:
             fdmod.ctx = orig
@@ -2204,7 +2216,6 @@ class TestManualRunMirror:
         orig = fdmod.ctx
         fdmod.ctx = _FakeCtx("submit_inputs")
         try:
-            app._initial_render_done = True
             raw(3, 4, 0, 1, None)                      # sid is None
         finally:
             fdmod.ctx = orig

--- a/tests/test_input_coercion.py
+++ b/tests/test_input_coercion.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python
+"""Callbacks receive the type their hint promises (#181, #182), and update_live
+apps render on every page load (#183)."""
+from __future__ import annotations
+
+import datetime
+import enum
+import json
+
+import pytest
+
+from fast_dash import FastDash
+from fast_dash.utils import _transform_inputs
+
+
+class Color(enum.Enum):
+    RED = "red"
+    BLUE = "blue"
+
+
+class Qty(enum.IntEnum):
+    ONE = 1
+    TWO = 2
+
+
+def _app(fn):
+    return FastDash(callback_fn=fn)
+
+
+def _coerce(app, index, value, tag):
+    return _transform_inputs([value], [tag], [app.inputs_with_ids[index]])[0]
+
+
+# --- #181: Enum ------------------------------------------------------------ #
+
+def test_enum_option_string_becomes_the_member():
+    def fn(c: Color = Color.RED) -> str:
+        """Echo."""
+        return str(c)
+
+    got = _coerce(_app(fn), 0, "blue", "Enum")
+    assert got is Color.BLUE          # `is` comparisons in user code now match
+    assert got.value == "blue"        # .value/.name no longer AttributeError
+    assert got.name == "BLUE"
+
+
+def test_enum_default_also_arrives_as_the_member():
+    # Even with nothing set, the stored default is the option *string*, so the
+    # untouched path needs coercing too.
+    def fn(c: Color = Color.RED) -> str:
+        """Echo."""
+        return str(c)
+
+    assert _coerce(_app(fn), 0, "red", "Enum") is Color.RED
+
+
+def test_int_enum_maps_through_its_stringified_value():
+    def fn(q: Qty = Qty.ONE) -> str:
+        """Echo."""
+        return str(q)
+
+    assert _coerce(_app(fn), 0, "2", "Enum") is Qty.TWO
+
+
+def test_enum_member_passes_through_untouched():
+    def fn(c: Color = Color.RED) -> str:
+        """Echo."""
+        return str(c)
+
+    assert _coerce(_app(fn), 0, Color.BLUE, "Enum") is Color.BLUE
+
+
+def test_unknown_enum_option_is_left_alone():
+    def fn(c: Color = Color.RED) -> str:
+        """Echo."""
+        return str(c)
+
+    assert _coerce(_app(fn), 0, "chartreuse", "Enum") == "chartreuse"
+
+
+# --- #182: date / datetime -------------------------------------------------- #
+
+def test_iso_string_becomes_a_date():
+    def fn(d: datetime.date = datetime.date(2024, 1, 15)) -> str:
+        """Echo."""
+        return str(d)
+
+    got = _coerce(_app(fn), 0, "2025-12-25", "Date")
+    assert got == datetime.date(2025, 12, 25)
+    assert got.isoformat() == "2025-12-25"     # used to AttributeError
+    assert got.year == 2025
+
+
+def test_iso_string_becomes_a_datetime():
+    def fn(t: datetime.datetime = datetime.datetime(2024, 1, 15, 10, 30)) -> str:
+        """Echo."""
+        return str(t)
+
+    got = _coerce(_app(fn), 0, "2024-01-15T10:30:00", "Timestamp")
+    assert got == datetime.datetime(2024, 1, 15, 10, 30)
+
+
+def test_date_picker_returning_a_full_timestamp_still_yields_a_date():
+    def fn(d: datetime.date = datetime.date(2024, 1, 15)) -> str:
+        """Echo."""
+        return str(d)
+
+    assert _coerce(_app(fn), 0, "2025-12-25T00:00:00", "Date") == datetime.date(2025, 12, 25)
+
+
+def test_real_date_passes_through_untouched():
+    # The untouched-default path already handed over a real date; keep it.
+    def fn(d: datetime.date = datetime.date(2024, 1, 15)) -> str:
+        """Echo."""
+        return str(d)
+
+    value = datetime.date(2024, 1, 15)
+    assert _coerce(_app(fn), 0, value, "Date") is value
+
+
+@pytest.mark.parametrize("junk", ["", "not-a-date", "2025-13-45"])
+def test_unparseable_date_is_not_mangled(junk):
+    def fn(d: datetime.date = datetime.date(2024, 1, 15)) -> str:
+        """Echo."""
+        return str(d)
+
+    assert _coerce(_app(fn), 0, junk, "Date") == junk
+
+
+def test_none_stays_none():
+    def fn(d: datetime.date = datetime.date(2024, 1, 15)) -> str:
+        """Echo."""
+        return str(d)
+
+    assert _coerce(_app(fn), 0, None, "Date") is None
+
+
+# --- #183: update_live renders on every page load --------------------------- #
+
+def _page_load(app, client, proc_key, proc, outs):
+    payload = {
+        "output": proc_key,
+        "outputs": [{"id": o.component_id, "property": o.component_property}
+                    for o in outs],
+        "inputs": [{"id": i["id"], "property": i["property"], "value": None}
+                   for i in proc["inputs"]],
+        "state": [{"id": s["id"], "property": s["property"], "value": None}
+                  for s in proc.get("state", [])],
+        "changedPropIds": [],
+    }
+    r = client.post("/_dash-update-component", data=json.dumps(payload),
+                    headers={"Content-Type": "application/json"})
+    return (r.get_json() or {}).get("response", {})
+
+
+def test_update_live_app_renders_on_every_page_load():
+    # Regression: _initial_render_done was instance state, so the page-load
+    # render happened once per worker *process*. The first visitor got a
+    # dashboard and every later visitor (or reload) got a silent blank one.
+    calls = []
+
+    def dashboard() -> str:
+        """Parameterless dashboard -- update_live is auto-enabled."""
+        calls.append(1)
+        return f"render {len(calls)}"
+
+    app = _app(dashboard)
+    assert app.update_live is True
+    client = app.app.server.test_client()
+    proc_key, proc = next(
+        (k, cb) for k, cb in app.app.callback_map.items()
+        if any(i.get("id") == "submit_inputs" for i in cb.get("inputs", []))
+        and any(i.get("id") == "reset_inputs" for i in cb.get("inputs", []))
+    )
+    out = proc["output"]
+    outs = out if isinstance(out, (list, tuple)) else [out]
+
+    for expected in (1, 2, 3):
+        response = _page_load(app, client, proc_key, proc, outs)
+        assert response, f"page load {expected} returned no outputs (blank page)"
+        rendered = " ".join(str(v) for v in response.values())
+        assert f"render {expected}" in rendered, rendered


### PR DESCRIPTION
Clears the open bug board: the three findings filed against 0.6.7.

## 🔴 #183 — `update_live` apps rendered only for the *first* visitor per worker process
`_initial_render_done` was a permanent latch on the **FastDash instance**, so the page-load render happened once per worker *process* rather than once per page load. The first visitor got a dashboard; **every later visitor — or a simple reload — got a blank one**, with no error and nothing in the console. Since every 0-input callback auto-enables `update_live`, this hit the plain parameterless dashboard, one of the things Fast Dash is best at.

The latch existed for a real reason: to stop the re-mount re-fire that follows a Run-reset from clobbering the outputs the Run had just rendered. But that children swap happens in **exactly one place**, so it now arms a **one-shot token** there, and the next no-trigger fire consumes it. Page loads never arm it, so they always render — and the clobber protection is unchanged.

## #181 — `enum.Enum` inputs passed the raw string, not the member
`.value` / `.name` raised `AttributeError`, and worse, `color is Color.RED` **silently never matched** — `ok: true`, wrong output. The Enum class is now kept on the component when the dropdown is built, and the value mapped back to its member.

## #182 — `datetime.date` inputs passed a raw ISO string once set
The callback got a real `date` only while the input was *untouched*; the moment a value was set (a human picking a date, or an agent's `set_input`/`invoke`) it became `"2025-12-25"` and `.isoformat()` / `.year` / `.weekday()` crashed. So an app worked until someone touched the picker. ISO strings are now parsed back to `date`/`datetime`.

Both coercions are conservative: a value that's already the right type passes through untouched, and an unparseable one is left alone rather than mangled. They apply on **every** surface — single, multi-function, steps and chat — because all four transform sites now receive their components.

## Verification
- **#183 in a real browser** (Playwright), which is where the symptom lives:
  ```
  1. first load     : 'rendered at 11:04:21.782658'
  2. reload         : 'rendered at 11:04:24.404446'
  3. second session : 'rendered at 11:04:27.710095'
  reload rendered / second session rendered / each load recomputed fresh → all True
  ```
  (Previously: load 1 rendered, loads 2 and 3 returned zero outputs.)
- **#181/#182** against the coercion path, including the `is`-comparison and `.isoformat()` cases the issues call out.

## Tests
New `tests/test_input_coercion.py` (14): Enum → member (incl. `IntEnum`, member passthrough, unknown option left alone), ISO → `date`/`datetime` (incl. a picker returning a full timestamp, real-date passthrough, unparseable/empty/`None` untouched), and three successive page loads each rendering fresh.

**Also rewrote a test that encoded the bug.** `test_remount_refire_returns_no_update_for_update_live` asserted "renders once, then `no_update` forever" — precisely the #183 behaviour. It now pins the corrected contract *and* the protection: every page load renders, only a token-armed re-fire is neutralised, and the token is one-shot.

**476 passed** across the non-browser suites; Selenium runs in CI.

Closes #181, closes #182, closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)
