### PR TITLE
fix: MCP contract batch — secret output leak, agent-path coercion, +6 (#186–#194)

### DIFF
--- a/fast_dash/Components.py
+++ b/fast_dash/Components.py
@@ -1381,6 +1381,16 @@ def _get_component_from_input(hint, default_value=None):
 
     # If hint has the attribute "component_property", it indicates that hint is a FastComponent, return it
     if hasattr(hint, "component_property"):
+        # ...but honour the signature's default. The exported components ship
+        # with a value baked in (Slider carries value=10), and returning the
+        # shared instance as-is silently dropped the declared default: a
+        # `level: Slider = 3` app rendered the handle at 10 and ran the callback
+        # with 10, while describe_app reported default 3 -- contradicting itself
+        # and the docs' "component used directly" pattern (issue #188). Copy
+        # before mutating so the shared exported component isn't rebound for
+        # every other app in the process.
+        if default_value is not None and not isinstance(default_value, type):
+            hint = hint(**{hint.component_property: default_value})
         return hint
 
     # Elif the component is a Dash component, use the specified component_property

--- a/fast_dash/mcp.py
+++ b/fast_dash/mcp.py
@@ -260,10 +260,59 @@ def _enumerate_outputs(fd) -> list[dict]:
     return descriptors
 
 
-def _param_name_from_id(component_id: str) -> str:
+def _param_name_from_id(component_id: str, callback_fn=None) -> str:
+    """Component id -> the callback keyword it feeds.
+
+    FastDash prefixes some generated ids with ``input_``, so the prefix is
+    stripped by default. But a *parameter can itself be named* ``input_...`` --
+    the Quickstart's own ``input_text`` is -- and blindly stripping then called
+    the callback with ``text=`` and raised TypeError, breaking that param on the
+    MCP path while the UI path worked (#189). When the callback is available,
+    an exact parameter match therefore wins over stripping.
+    """
+    if callback_fn is not None:
+        try:
+            if component_id in inspect.signature(callback_fn).parameters:
+                return component_id
+        except (TypeError, ValueError):
+            pass
     if component_id.startswith("input_"):
         return component_id[len("input_"):]
     return component_id
+
+
+def _coerce_for_callback(fd, kwargs):
+    """Give the callback the types its hints promise, as the UI path does.
+
+    ``_transform_inputs`` coerces a Select's option string back to the Enum
+    member (#181), a picker's ISO string back to date/datetime (#182) and an
+    upload's data URL to a PIL image -- but only on the UI callback path. The
+    MCP drive path called the callback with the raw mirror values, so the same
+    input driven by an agent and by a human produced *different argument types*
+    and a realistic callback worked in the UI and broke over MCP (#186).
+    """
+    from fast_dash.utils import _b64_to_pil, _coerce_date, _coerce_enum
+
+    for comp in list(getattr(fd, "inputs_with_ids", None) or []):
+        cid = _stringify_id(comp.id)
+        param = _param_name_from_id(cid, getattr(fd, "callback_fn", None))
+        key = cid if cid in kwargs else param if param in kwargs else None
+        if key is None:
+            continue
+        value = kwargs[key]
+        if value is None:
+            continue
+        tag = getattr(comp, "tag", None)
+        if tag == "Enum":
+            kwargs[key] = _coerce_enum(value, comp)
+        elif tag in ("Date", "Timestamp"):
+            kwargs[key] = _coerce_date(value, tag)
+        elif tag == "Image":
+            try:
+                kwargs[key] = _b64_to_pil(value)
+            except Exception:             # noqa: BLE001 - leave odd values alone
+                pass
+    return kwargs
 
 
 def _seed_input_mirror(fd) -> None:
@@ -318,6 +367,12 @@ def _json_type_name(annotation) -> str:
         import types as _types
         import typing
 
+        # Unwrap Annotated[T, ...] to T. The metadata is not part of the value's
+        # JSON type, and an Annotated carrying a *list* of options is itself
+        # unhashable -- so leaving it wrapped made the dict lookup below raise
+        # once the contract started reading Annotated metadata (issue #192).
+        if hasattr(annotation, "__metadata__"):
+            annotation = typing.get_args(annotation)[0]
         origin = typing.get_origin(annotation)
         is_union = origin is typing.Union or (
             hasattr(_types, "UnionType") and origin is _types.UnionType
@@ -328,10 +383,13 @@ def _json_type_name(annotation) -> str:
                 annotation = members[0]
     except Exception:
         pass
-    return {
-        int: "integer", float: "number", str: "string",
-        bool: "boolean", list: "array", dict: "object",
-    }.get(annotation, "string")
+    try:
+        return {
+            int: "integer", float: "number", str: "string",
+            bool: "boolean", list: "array", dict: "object",
+        }.get(annotation, "string")
+    except TypeError:                 # unhashable annotation: not a scalar type
+        return "string"
 
 
 # JSON type each DynamicDash spec component emits. Lets describe_app report a
@@ -355,7 +413,7 @@ def _spec_json_type(spec_type) -> str:
 
 
 def _annotation_options(annotation):
-    """Allowed values for a Literal[...] or Enum annotation, else None."""
+    """Allowed values for a Literal / Enum / Annotated[T, [...]] hint, else None."""
     try:
         import enum
         import typing
@@ -365,6 +423,17 @@ def _annotation_options(annotation):
             # Match the UI Select, which is built with str(e.value) options — so
             # an IntEnum's options are ["1", "2"], not [1, 2] (issue #126).
             return [str(e.value) for e in annotation]
+        # Annotated[str, ["a", "b"]] renders a Select in the UI, but the contract
+        # never extracted its options: describe_app reported `options: null`, so
+        # the validators had nothing to enforce and set_input accepted a value
+        # the dropdown could never emit (issue #192).
+        if typing.get_origin(annotation) is not None and hasattr(annotation, "__metadata__"):
+            for meta in annotation.__metadata__:
+                if isinstance(meta, (list, tuple)) and meta:
+                    return list(meta)
+            # Annotated[T, ...] with non-option metadata (e.g. a range for a
+            # Slider): fall back to the wrapped type's own options.
+            return _annotation_options(typing.get_args(annotation)[0])
     except Exception:
         pass
     return None
@@ -391,6 +460,46 @@ def _resolve_depends_on_options(fd, dep, snapshot):
     return list(data) if isinstance(data, list) else None
 
 
+def _clear_stale_dependents(fd, state) -> list:
+    """Drop a ``depends_on`` child's value once the parent invalidates it (#191).
+
+    The browser cascade clears the dependent dropdown when its parent changes.
+    The MCP path re-resolved the child's *options* but kept its old *value*, so
+    ``describe_app`` ended up advertising a ``current_value`` that isn't in its
+    own ``options`` -- and the two drive paths disagreed about it, ``set_input``
+    rejecting the value that ``invoke`` would happily run. Returns the ids
+    cleared, so callers can report them.
+    """
+    from fast_dash.utils import depends_on
+
+    try:
+        sig_params = inspect.signature(fd.callback_fn).parameters
+    except (TypeError, ValueError):
+        return []
+
+    cleared = []
+    for comp in list(getattr(fd, "inputs_with_ids", None) or []):
+        cid = _stringify_id(comp.id)
+        param = _param_name_from_id(cid, getattr(fd, "callback_fn", None))
+        p = sig_params.get(param) or sig_params.get(cid)
+        dep = getattr(p, "default", None) if p is not None else None
+        if not isinstance(dep, depends_on):
+            continue
+        snapshot = dict(state.inputs)
+        current = snapshot.get(cid, snapshot.get(param))
+        if current is None:
+            continue
+        options = _resolve_depends_on_options(fd, dep, snapshot)
+        if options is not None and current not in options:
+            for key in (cid, param):
+                state.inputs.pop(key, None)
+            # Push the clear to the live browser too, so the widget doesn't keep
+            # showing a value the contract no longer accepts.
+            state.pending_inputs[cid] = None
+            cleared.append(cid)
+    return cleared
+
+
 def _component_bounds(comp):
     """Numeric ``{min, max, step}`` carried by a Slider/number component, else {}.
 
@@ -413,6 +522,11 @@ def _component_bounds(comp):
 # What an agent sees instead of a secret's value. Not a valid value for any
 # widget, so a round-trip of describe_app -> set_input can't silently re-send it.
 REDACTED = "********"
+
+# The keys a DynamicDash spec may carry (what _spec_to_component consumes).
+# `default` is accepted too, as an alias for `value`, so describe_app's own
+# output round-trips back through set_form (issue #193).
+_SPEC_KEYS = frozenset({"name", "type", "label", "value", "props"})
 
 
 def _is_password_component(comp) -> bool:
@@ -443,6 +557,49 @@ def _secret_ids(fd, state=None) -> set:
     if state is not None:
         ids.update(getattr(state, "secret_ids", None) or set())
     return ids
+
+
+def _secret_values(fd, state=None) -> list:
+    """Current values of the app's secret inputs, as non-empty strings."""
+    if state is None:
+        state = getattr(fd, "_mcp_state", None)
+    mirror = dict(getattr(state, "inputs", None) or {})
+    values = []
+    for cid in _secret_ids(fd, state):
+        value = mirror.get(cid)
+        if isinstance(value, str) and value.strip():
+            values.append(value)
+    return values
+
+
+def _scrub_secrets(payload, secrets):
+    """Mask any secret that shows up *inside* an output payload (#194).
+
+    The input axis of this leak was closed in #151 (describe_app's
+    current_value, the set_input echo, get_invocation's kwargs). But the
+    callback's OUTPUT went back unredacted, so the canonical decrypt/echo app --
+    one that derives its output from a PasswordInput -- handed the credential
+    straight to any agent that could reach the unauthenticated /mcp. Within one
+    get_invocation response the input showed as ``********`` while the output
+    returned the very same string in the clear.
+
+    Redaction is by *content*, not by field: the secret is masked wherever it
+    appears in a summary, including nested inside a str/list/dict, because a
+    field-level mask leaks through siblings and stringified containers.
+    """
+    if not secrets:
+        return payload
+    if isinstance(payload, str):
+        scrubbed = payload
+        for secret in secrets:
+            if secret in scrubbed:
+                scrubbed = scrubbed.replace(secret, REDACTED)
+        return scrubbed
+    if isinstance(payload, dict):
+        return {k: _scrub_secrets(v, secrets) for k, v in payload.items()}
+    if isinstance(payload, (list, tuple)):
+        return type(payload)(_scrub_secrets(v, secrets) for v in payload)
+    return payload
 
 
 def _redact(entry, value):
@@ -592,7 +749,10 @@ def _describe_static_inputs(fd, snapshot):
     # types; fall back to the raw annotation.
     try:
         import typing
-        hints = typing.get_type_hints(fd.callback_fn)
+        # include_extras keeps Annotated[...] metadata; without it the options
+        # of an Annotated[str, [...]] dropdown are stripped before the contract
+        # can read them (issue #192).
+        hints = typing.get_type_hints(fd.callback_fn, include_extras=True)
     except Exception:
         hints = {}
 
@@ -600,7 +760,7 @@ def _describe_static_inputs(fd, snapshot):
     contract = []
     for d in descriptors:
         cid = d["id"]
-        param = _param_name_from_id(cid)
+        param = _param_name_from_id(cid, getattr(fd, "callback_fn", None))
         p = sig_params.get(param) or sig_params.get(cid)
         jtype, default, options = "string", None, None
         if p is not None:
@@ -929,7 +1089,8 @@ def _describe_chat_settings(fd) -> list[dict]:
         return []
     settings = _describe_static_inputs(fd, dict(fd._mcp_state.inputs))
     for entry in settings:
-        entry["name"] = _param_name_from_id(entry["id"])
+        entry["name"] = _param_name_from_id(
+            entry["id"], getattr(fd, "callback_fn", None))
     return settings
 
 
@@ -1091,7 +1252,13 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             return {"ok": False, "error": bad, "id": component_id}
         state.inputs[component_id] = value
         state.pending_inputs[component_id] = value
-        return {"ok": True, "id": component_id, "value": _echo(entries, component_id, value)}
+        # Changing a depends_on parent invalidates its child's value (#191).
+        cleared = _clear_stale_dependents(fd, state)
+        out = {"ok": True, "id": component_id,
+               "value": _echo(entries, component_id, value)}
+        if cleared:
+            out["cleared"] = cleared
+        return out
 
     @mcp_enabled(name="set_inputs", expose_docstring=True)
     @_structured_errors
@@ -1115,7 +1282,11 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             state.pending_inputs[k] = v
             snapshot[k] = v
             applied[k] = _echo(entries, k, v)
-        return {"ok": not errors, "applied": applied, "errors": errors}
+        cleared = _clear_stale_dependents(fd, state)          # #191
+        out = {"ok": not errors, "applied": applied, "errors": errors}
+        if cleared:
+            out["cleared"] = cleared
+        return out
 
     @mcp_enabled(name="invoke", expose_docstring=True)
     @_structured_errors
@@ -1156,6 +1327,7 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             for k, v in inputs.items():
                 state.inputs[k] = v
                 state.pending_inputs[k] = v
+            _clear_stale_dependents(fd, state)                # #191
 
         kwargs = {}
         snapshot = dict(state.inputs)
@@ -1163,13 +1335,17 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         if descriptors:
             for d in descriptors:
                 cid = d["id"]
-                param = _param_name_from_id(cid)
+                param = _param_name_from_id(cid, fd.callback_fn)
                 if cid in snapshot:
                     kwargs[param] = snapshot[cid]
                 elif param in snapshot:
                     kwargs[param] = snapshot[param]
         else:
             kwargs = dict(snapshot)
+
+        # Same coercion the UI path applies, so an agent-driven run and a human
+        # Run hand the callback identical argument types (#186).
+        kwargs = _coerce_for_callback(fd, kwargs)
 
         # Secrets go into the callback but never come back out — not in the
         # error echo, and not in the history a later get_invocation reads (#151).
@@ -1198,11 +1374,16 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
         dt_ms = round((time.time() - t0) * 1000, 1)
 
         result_list = list(result) if isinstance(result, (list, tuple)) else [result]
+        # A callback that derives its output from a PasswordInput would otherwise
+        # hand the credential back in the clear -- the output axis of the #151
+        # leak. The live browser still receives the real value; only what goes
+        # back over /mcp is scrubbed (#194).
+        secrets = _secret_values(fd, state)
         out_summary = {}
         for d, val in zip(_enumerate_outputs(fd), result_list):
             state.outputs[d["id"]] = val
             state.pending_outputs[d["id"]] = val
-            out_summary[d["id"]] = _summarize_for_history(val)
+            out_summary[d["id"]] = _scrub_secrets(_summarize_for_history(val), secrets)
 
         entry_summary = {
             "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
@@ -1233,6 +1414,45 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
             return {"ok": False, "error": "set_form requires a DynamicDash app"}
         if not isinstance(specs, list):
             return {"ok": False, "error": "specs must be a list of dicts"}
+
+        # `default` is the key describe_app reports an initial value under, so
+        # accept it as an alias for the `value` render_spec actually reads --
+        # otherwise describe_app's own vocabulary silently fails to round-trip
+        # through set_form and the field renders empty (issue #193).
+        normalized = []
+        for spec in specs:
+            if isinstance(spec, dict) and "default" in spec and "value" not in spec:
+                spec = {**spec, "value": spec["default"]}
+                spec.pop("default", None)
+            normalized.append(spec)
+        specs = normalized
+
+        # Anything else unrecognized is a typo, not a no-op: silently dropping it
+        # returned ok:true for a form that isn't what the agent asked for.
+        for spec in specs:
+            if not isinstance(spec, dict):
+                continue
+            unknown = sorted(set(spec) - _SPEC_KEYS)
+            if unknown:
+                return {
+                    "ok": False,
+                    "error": f"unknown spec key(s): {unknown}",
+                    "allowed_keys": sorted(_SPEC_KEYS | {"default"}),
+                    "spec": spec,
+                }
+
+        # Two fields sharing a name can't both reach the callback (it takes
+        # **kwargs, and a dict can't hold a key twice), so describe_app would
+        # advertise a contract the app can never honour (issue #190).
+        names = [s.get("name") for s in specs if isinstance(s, dict)]
+        duplicates = sorted({n for n in names if n and names.count(n) > 1})
+        if duplicates:
+            return {
+                "ok": False,
+                "error": f"duplicate field name(s): {duplicates}",
+                "hint": "each spec needs a unique 'name' -- it is the callback kwarg",
+            }
+
         for spec in specs:
             try:
                 _spec_to_component(spec)
@@ -1258,12 +1478,16 @@ def enable_mcp(fd, *, mcp_path: str = "mcp") -> None:
                 "available": list(state.full_history.keys()),
             }
         entry = state.full_history[index]
+        # History is written already scrubbed; scrub again on the way out so a
+        # secret can't survive in an entry written by some other path, and so a
+        # value that became secret after the fact is still masked (#194).
+        secrets = _secret_values(fd, state)
         return {
             "ok": True,
             "ts": entry["ts"],
             "duration_ms": entry["duration_ms"],
-            "kwargs_summary": entry["kwargs"],
-            "outputs_summary": entry["outputs"],
+            "kwargs_summary": _scrub_secrets(entry["kwargs"], secrets),
+            "outputs_summary": _scrub_secrets(entry["outputs"], secrets),
         }
 
     @mcp_enabled(name="list_component_types", expose_docstring=True)

--- a/tests/test_component_hint_defaults.py
+++ b/tests/test_component_hint_defaults.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+"""A Fast Dash component used as a type hint honours the signature default (#188).
+
+Deliberately WITHOUT ``from __future__ import annotations``: under string
+annotations ``level: Slider`` never resolves to the component object, so these
+would silently exercise a text input instead and pass for the wrong reason.
+"""
+from fast_dash import FastDash, Slider
+
+
+def _value(app):
+    component = app.inputs_with_ids[0]
+    return getattr(component, component.component_property, "<missing>")
+
+
+def test_component_hint_honours_the_signature_default():
+    # The exported Slider ships value=10 baked in and was used as-is, so
+    # `level: Slider = 3` silently ran the callback with 10 while the UI handle
+    # rendered at 10 too -- the documented "component used directly" pattern
+    # quietly ignoring the declared default.
+    def fn(level: Slider = 3) -> str:
+        """Echo."""
+        return f"got {level}"
+
+    assert _value(FastDash(callback_fn=fn)) == 3
+
+
+def test_component_hint_without_a_default_keeps_the_builtin_value():
+    def fn(level: Slider) -> str:
+        """Echo."""
+        return f"got {level}"
+
+    assert _value(FastDash(callback_fn=fn)) == 10
+
+
+def test_component_hint_default_does_not_leak_across_apps():
+    # The exported components are shared module-level singletons, so applying a
+    # default must copy rather than rebind them for every later app.
+    def first(level: Slider = 3) -> str:
+        """A."""
+        return str(level)
+
+    def second(level: Slider) -> str:
+        """B."""
+        return str(level)
+
+    assert _value(FastDash(callback_fn=first)) == 3
+    assert _value(FastDash(callback_fn=second)) == 10
+    assert Slider.value == 10           # the shared export is untouched

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1345,3 +1345,136 @@ def test_asgi_backend_announces_its_url(monkeypatch, capsys):
     assert "8091" in out and "http://" in out, f"no URL announced: {out!r}"
     # uvicorn's own startup/shutdown lines are no longer suppressed.
     assert captured["config"].log_level == "info"
+
+
+class TestDogfoodBatchAug06:
+    """Regressions for the bugs the nightly dogfood filed against 0.6.8."""
+
+    # --- #194: secrets must not escape via OUTPUT content ------------------ #
+
+    def test_secret_is_scrubbed_from_invoke_and_history_output(self):
+        # #151 closed the input axis (describe_app / set_input echo / kwargs).
+        # A callback that DERIVES its output from the secret handed it straight
+        # back, so an agent that "cannot read it" read it by invoking.
+        def reveal(pwd: PasswordInput = "") -> str:
+            """Echo the secret."""
+            return f"decrypted: {pwd}"
+
+        app = FastDash(callback_fn=reveal, mcp_server=True)
+        c = _client_for(app)
+        _call(c, "set_input", {"component_id": "pwd", "value": "hunter2"})
+
+        # Assert by substring over the WHOLE payload: a field-level mask leaks
+        # through siblings and stringified containers.
+        assert "hunter2" not in json.dumps(_call(c, "invoke", {}))
+        assert "hunter2" not in json.dumps(_call(c, "get_invocation", {"index": 0}))
+
+    def test_non_secret_output_is_not_scrubbed(self):
+        def echo(word: str = "hello") -> str:
+            """Echo."""
+            return f"said {word}"
+
+        c = _client_for(FastDash(callback_fn=echo, mcp_server=True))
+        assert "said hello" in json.dumps(_call(c, "invoke", {}))
+
+    # --- #186: the agent path coerces inputs like the UI path -------------- #
+
+    def test_invoke_hands_the_callback_enum_members_and_dates(self):
+        # 0.6.8 coerced only the UI path, so the same input driven by an agent
+        # arrived as a raw option string / ISO string -- a parity break that
+        # re-opened #181 and #182 on the flagship agent surface.
+        def describe(flavor: Flavor = Flavor.VANILLA,
+                     when: datetime.date = datetime.date(2024, 1, 1)) -> str:
+            """Report what the callback actually received."""
+            return (f"{type(flavor).__name__}|{flavor is Flavor.CHOCO}"
+                    f"|{type(when).__name__}")
+
+        c = _client_for(FastDash(callback_fn=describe, mcp_server=True))
+        out = json.dumps(_call(c, "invoke",
+                               {"inputs": {"flavor": "choco", "when": "2025-12-25"}}))
+        assert "Flavor|True|date" in out
+
+    # --- #189: a parameter literally named input_* ------------------------- #
+
+    def test_invoke_drives_a_param_named_input_something(self):
+        # The drive path stripped a leading `input_`, so the Quickstart's own
+        # `input_text` param was called as `text=` and raised TypeError -- while
+        # set_input still returned ok:true, hiding the failure until invoke.
+        def text_to_text_function(input_text: str = "hi") -> str:
+            """Quickstart."""
+            return input_text.upper()
+
+        c = _client_for(FastDash(callback_fn=text_to_text_function, mcp_server=True))
+        out = _call(c, "invoke", {"inputs": {"input_text": "hello"}})
+        assert out["ok"] is True, out
+        assert "HELLO" in json.dumps(out["outputs"])
+
+    # --- #192: Annotated[str, [...]] carries its options ------------------- #
+
+    def test_annotated_dropdown_options_reach_the_contract(self):
+        def pick(choice: Annotated[str, ["p", "q"]] = "p") -> str:
+            """Pick."""
+            return choice
+
+        c = _client_for(FastDash(callback_fn=pick, mcp_server=True))
+        entry = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}["choice"]
+        assert entry["options"] == ["p", "q"]
+        # ...and the contract is now enforced, as the docs promise.
+        assert _call(c, "set_input",
+                     {"component_id": "choice", "value": "z"})["ok"] is False
+        assert _call(c, "set_input",
+                     {"component_id": "choice", "value": "q"})["ok"] is True
+
+    # --- #190 / #193: set_form spec validation ----------------------------- #
+
+    def test_set_form_rejects_duplicate_field_names(self):
+        c = _client_for(_dynamic_app())
+        out = _call(c, "set_form", {"specs": [
+            {"name": "a", "type": "Text"}, {"name": "a", "type": "Text"}]})
+        assert out["ok"] is False
+        assert "duplicate" in out["error"]
+
+    def test_set_form_rejects_unknown_spec_keys(self):
+        c = _client_for(_dynamic_app())
+        out = _call(c, "set_form",
+                    {"specs": [{"name": "a", "type": "Text", "bogus": 1}]})
+        assert out["ok"] is False
+        assert "bogus" in out["error"]
+
+    def test_describe_app_default_round_trips_through_set_form(self):
+        # describe_app reports an initial value under `default`, but render_spec
+        # reads `value` -- so feeding describe_app's own output back silently
+        # produced an empty field.
+        c = _client_for(_dynamic_app())
+        assert _call(c, "set_form", {"specs": [
+            {"name": "a", "type": "Text", "default": "seeded"}]})["ok"] is True
+        entry = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}["a"]
+        assert entry["default"] == "seeded"
+
+    # --- #191: a depends_on child loses its stale value -------------------- #
+
+    def test_changing_a_depends_on_parent_clears_the_child(self):
+        # The browser cascade clears the dependent dropdown; the MCP path
+        # re-resolved its options but kept the old value, so describe_app
+        # advertised a current_value outside its own options and the two drive
+        # paths disagreed (set_input rejected what invoke would run).
+        from fast_dash import depends_on
+
+        countries = {"USA": ["CA", "TX"], "India": ["MH", "KA"]}
+
+        def pick(country: str = ["USA", "India"],
+                 state: str = depends_on("country", lambda c: countries[c])) -> str:
+            """Pick."""
+            return f"{state}, {country}"
+
+        c = _client_for(FastDash(callback_fn=pick, mcp_server=True))
+        _call(c, "set_input", {"component_id": "country", "value": "USA"})
+        assert _call(c, "set_input",
+                     {"component_id": "state", "value": "TX"})["ok"] is True
+
+        # Switching the parent invalidates "TX".
+        _call(c, "set_input", {"component_id": "country", "value": "India"})
+        entry = {i["id"]: i for i in _call(c, "describe_app")["inputs"]}["state"]
+        assert entry["current_value"] != "TX", "stale child value survived"
+        if entry["options"] is not None and entry["current_value"] is not None:
+            assert entry["current_value"] in entry["options"]


### PR DESCRIPTION
Clears all eight open bugs. Seven are on the MCP contract surface, so they share a fix site and tests; the eighth (#188) is the UI-side sibling of the same "a documented type hint lies to the callback" class.

## 🔴 #194 — a secret escaped via OUTPUT content *(security)*
`invoke` / `get_invocation` returned the callback's output **unredacted**, so the canonical decrypt/echo app — one that derives its output from a `PasswordInput` — handed the credential to any agent that could reach the unauthenticated `/mcp`. Within a *single* `get_invocation` the input showed as `********` while the output returned the same string in the clear, defeating the docs' unconditional *"an agent can fill the field; it cannot read it"*.

#151 closed the input axis; this closes the output axis. Redaction is **by content, not by field** — masked wherever the secret appears, including nested in a str/list/dict — because a field-level mask leaks through siblings and stringified containers. `get_invocation` scrubs again on the way out. The live browser still receives the real value.

## #186 — the agent path skipped the coercion 0.6.8 just shipped
`invoke`/`set_inputs` handed the callback a raw option string / ISO string where a UI Run handed it an Enum member / `date` — re-opening #181 and #182 on the flagship agent surface and breaking the documented human↔agent parity. (This was a gap in my own 0.6.8 fix: I coerced the UI path only.)

## #189 — a parameter named `input_*` couldn't be driven
The drive path stripped a leading `input_`, so the **Quickstart's own `input_text`** was called as `text=` → `TypeError`, while `set_input` still returned `ok:true`, hiding the failure until `invoke`. An exact parameter match now wins over stripping.

## #192 — `Annotated[str, [...]]` lost its options
`get_type_hints` drops `Annotated` metadata unless `include_extras=True`, so `describe_app` reported `options: null` and the validators had nothing to enforce — `set_input` accepted a value the UI's Select could never emit. Fixing that surfaced a latent crash: an `Annotated` carrying a **list** is unhashable and blew up the JSON-type dict lookup, so the annotation is now unwrapped first.

## #191 — a `depends_on` child kept its stale value
Changing the parent over MCP re-resolved the child's *options* but not its *value*, so `describe_app` advertised a `current_value` outside its own `options`, and the drive paths disagreed — `set_input` rejecting what `invoke` would happily run. The child is now cleared, in the mirror **and** in the browser, as the UI cascade does.

## #190 / #193 — `set_form` accepted contracts it couldn't honour
- **#190**: duplicate field names advertised two inputs sharing one id that the callback can never both receive → rejected.
- **#193**: unknown spec keys were silently dropped, including `default` — the very key `describe_app` emits for an initial value — so feeding `describe_app`'s own output back returned `ok:true` with an empty field. `default` is now an accepted alias for `value` (the vocabulary round-trips), and genuine typos are rejected instead of ignored.

## #188 — a component used as a type hint ignored the declared default
The exported `Slider` ships `value=10` and was used as-is, so `level: Slider = 3` ran with **10** while `describe_app` reported 3. Applied to a **copy**, so the shared module-level export isn't rebound for every later app in the process.

## Tests
12 new. **502 passed** across the non-browser suites; Selenium runs in CI.

Two worth calling out:
- **#194 is asserted by substring over the whole serialized payload**, not per-field — the only way to catch a leak through a sibling or a stringified container.
- **#188's tests live in their own file, deliberately without `from __future__ import annotations`.** Under string annotations `level: Slider` never resolves to the component, so my first attempt exercised a text input and **passed for the wrong reason**; the singleton-leak test is what exposed it.

Closes #186, #188, #189, #190, #191, #192, #193, #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)
