### PR TITLE
fix(chat): point a mistyped chatbot callback at the query rule, not the agent extra

### DIFF
--- a/fast_dash/fast_dash.py
+++ b/fast_dash/fast_dash.py
@@ -115,6 +115,29 @@ def _is_chat_shaped(callback_fn):
     return bool(params) and params[0] == "query"
 
 
+def _looks_like_mistyped_chatbot(callback_fn):
+    """True if ``callback_fn`` reads like a chat handler whose first parameter
+    is simply not named ``query``.
+
+    ``chat=True`` misses the signature tiebreak when the first parameter is not
+    ``query`` and is then treated as an app callback wanting an auto-built agent
+    sidecar. A single callback whose first parameter is a plain text param
+    (annotation empty or ``str``) is far more likely the docs' 5-line chatbot
+    with a mistyped first parameter than a normal app. Used to pick the
+    on-topic error (see ``_check_auto_agent_prereqs``).
+    """
+    if callback_fn is None or isinstance(callback_fn, list):
+        return False
+    try:
+        params = list(inspect.signature(callback_fn).parameters.values())
+    except (TypeError, ValueError):
+        return False
+    if not params:
+        return False
+    annotation = params[0].annotation
+    return annotation is inspect.Parameter.empty or annotation in (str, "str")
+
+
 def _is_model_instance(obj):
     """Duck-type a chat model instance (LangChain BaseChatModel and friends).
 
@@ -589,7 +612,7 @@ class FastDash(ChatAppMixin):
                 # Fail early with a friendly ASCII error if the [agent] extra is
                 # unavailable OR no model is configured (chat_model / env). The
                 # real agent is built lazily by Round 3's build_auto_agent.
-                self._check_auto_agent_prereqs()
+                self._check_auto_agent_prereqs(callback_fn)
             else:
                 self._chat_agent = _agent
             self.chat_tools_config = _resolve_chat_tools(
@@ -713,7 +736,7 @@ class FastDash(ChatAppMixin):
         else:
             self._init_single_function(callback_fn, inputs, outputs, output_labels, update_live)
 
-    def _check_auto_agent_prereqs(self):
+    def _check_auto_agent_prereqs(self, callback_fn):
         """Fail fast (friendly, ASCII) when an auto-agent can't be built later.
 
         chat=True on an app callback auto-builds an assistant via
@@ -732,6 +755,33 @@ class FastDash(ChatAppMixin):
             and importlib.util.find_spec("langgraph") is not None
         )
         if not has_agent_extra:
+            if (
+                self.chat_model is None
+                and not os.environ.get("FASTDASH_MODEL")
+                and _looks_like_mistyped_chatbot(callback_fn)
+            ):
+                # A callback shaped like the docs' 5-line chatbot (one plain
+                # text param, no model configured) that missed the `query`
+                # tiebreak almost certainly did not mean "normal app + agent
+                # sidecar". Raise the on-topic message the chat docs promise
+                # instead of pointing at the [agent] extra (issue #214).
+                try:
+                    _params = list(inspect.signature(callback_fn).parameters)
+                except (TypeError, ValueError):
+                    _params = []
+                raise TypeError(
+                    "chat=True with %s: a chat callback's first parameter "
+                    "must be named 'query' (it receives the composer text). "
+                    "Did you mean def %s(query: ...)? Got signature (%s). "
+                    "If you meant to attach an auto-built agent to a normal "
+                    "app instead, install \"fast-dash[agent]\" and pass "
+                    "chat_model= (or set FASTDASH_MODEL)."
+                    % (
+                        getattr(callback_fn, "__name__", repr(callback_fn)),
+                        getattr(callback_fn, "__name__", "callback"),
+                        ", ".join(_params),
+                    )
+                )
             raise ImportError(
                 "chat=True auto-builds an assistant, which needs the optional "
                 "agent extra (langchain + langgraph). Install it with:\n"

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -313,6 +313,33 @@ class TestChatConstruction:
             FastDash(chat=bot)
         assert "query" in str(ei.value) and str(ei.value).isascii()
 
+    @pytest.mark.skipif(
+        _HAS_AGENT, reason="misdirection only bites when the agent extra is absent"
+    )
+    def test_nonquery_first_param_points_at_query_rule(self, monkeypatch):
+        # Issue #214: chat=True with a non-`query` first param is reinterpreted
+        # as an app callback needing an auto-built sidecar, and dies with a
+        # misleading ImportError about the [agent] extra. When the callback
+        # actually looks like the docs' 5-line chatbot (one bare str param, no
+        # model configured), the on-topic "must be named 'query'" message must
+        # win -- and still name the sidecar interpretation.
+        monkeypatch.delenv("FASTDASH_MODEL", raising=False)
+
+        def assistant(prompt: str):
+            yield "hi"
+        with pytest.raises(TypeError) as ei:
+            FastDash(callback_fn=assistant, chat=True)
+        msg = str(ei.value)
+        assert "query" in msg and msg.isascii()
+        assert "fast-dash[agent]" in msg
+
+        # An app-shaped callback (typed non-str params) keeps the ImportError:
+        # it reads as a normal app wanting a sidecar, not a mistyped chatbot.
+        def dashboard(revenue: int = 100) -> str:
+            return str(revenue)
+        with pytest.raises(ImportError):
+            FastDash(callback_fn=dashboard, chat=True)
+
     def test_update_live_incompatible(self):
         def bot(query):
             yield "hi"


### PR DESCRIPTION
Closes #214 (proposal 2).

Problem:
- `chat=True` with a callback whose first parameter is not `query` misses the signature tiebreak and is reinterpreted as an app callback needing an auto-built agent sidecar, so construction dies with `ImportError: ... pip install "fast-dash[agent]"` — misdirecting anyone who followed the 5-line chatbot docs and mistyped the composer parameter. The chat docs promise a clear "first parameter must be `query`" rejection for this case, and the other three documented rejections do fire correctly; only this one is unreachable.

Solution:
- Inside `_check_auto_agent_prereqs` — the exact spot that raises the misleading `ImportError` — detect the likely-chatbot shape: no `chat_model=`, no `FASTDASH_MODEL`, no agent extra installed, and a first parameter annotated as plain text (`str` or no annotation). In that case raise the on-topic "first parameter must be named 'query'" message, naming both interpretations (rename to `query`, or install `fast-dash[agent]` + pass `chat_model=` if a sidecar was intended). Typed app callbacks keep the existing `ImportError`, and users with the extra installed are unaffected since the check runs on the error path only.

Result:
- `FastDash(callback_fn=assistant, chat=True)` with `def assistant(prompt: str)` now raises the on-topic `TypeError` (ASCII); a typed `dashboard(revenue: int)` callback still gets the `ImportError`, as do `chat_model=` / `FASTDASH_MODEL` setups.
- New regression test in `TestChatConstruction` covers both directions; verified red without the fix, green with it.
- All non-browser tests pass locally (`test_chat.py` + 15 other files: 442 passed, 61 skipped; the 3 browser-based files need Chrome, unavailable here). `flake8` count on `fast_dash.py` unchanged (46, all pre-existing).